### PR TITLE
Add GitHub issue templates for bugs, features, and support

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,105 @@
+name: Bug report
+description: Report broken behavior, regressions, crashes, or incorrect results
+title: "[bug] "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        yoink is still in alpha and is not production ready yet.
+
+        Please include exact reproduction steps and any sanitized logs or screenshots that help explain the problem.
+  - type: dropdown
+    id: affected_area
+    attributes:
+      label: Affected area
+      description: Which part of yoink is involved?
+      options:
+        - Backend/API
+        - Frontend/UI
+        - Downloads
+        - Import
+        - Providers/metadata
+        - Authentication
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: yoink version / commit / image tag
+      description: For example `main@<commit>`, `v0.x.y`, or a Docker image tag.
+      placeholder: main@abcdef1
+    validations:
+      required: true
+  - type: dropdown
+    id: install_method
+    attributes:
+      label: Install method
+      options:
+        - Docker / Compose
+        - From source
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: browser
+    attributes:
+      label: Browser and version
+      description: Optional if the issue is UI-related.
+      placeholder: Firefox 137 / Chrome 135 / Safari 18
+  - type: textarea
+    id: providers
+    attributes:
+      label: Provider setup involved
+      description: List any providers or integrations involved and any relevant context.
+      placeholder: |
+        Tidal
+        Deezer
+        MusicBrainz
+        SoulSeek/slskd
+        Other relevant integration context
+      render: text
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Go to ...
+        2. Click ...
+        3. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / stack traces
+      description: Paste any sanitized logs, errors, or stack traces here.
+      render: shell
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Screenshots / recordings / API response snippets
+      description: Add screenshots, recordings, or sanitized response snippets if they help.
+  - type: checkboxes
+    id: confirmations
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues first.
+          required: true
+        - label: I can still reproduce this on the latest `main` branch or latest release/image available to me.
+          required: true
+        - label: I removed or redacted secrets from logs, screenshots, and config snippets.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,72 @@
+name: Feature request
+description: Propose a new capability or improvement
+title: "[feature] "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please describe the problem first, then the solution you want.
+
+        yoink is still in alpha, so some ideas may be deferred if they add too much scope too early.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / use case
+      description: What are you trying to do, and what is missing today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe the change you want to see.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Optional. Describe workarounds or other ideas you considered.
+  - type: dropdown
+    id: area
+    attributes:
+      label: Feature area
+      options:
+        - Search
+        - Downloads
+        - Library management
+        - Import
+        - Metadata/providers
+        - UI/UX
+        - API/integrations
+        - Auth/users
+        - Other
+    validations:
+      required: true
+  - type: dropdown
+    id: impact
+    attributes:
+      label: Audience / impact
+      options:
+        - Only my setup
+        - Some advanced users
+        - Most users
+    validations:
+      required: true
+  - type: textarea
+    id: prior_art
+    attributes:
+      label: Related tools or prior art
+      description: Optional. Link similar behavior in other tools, apps, or repos.
+  - type: textarea
+    id: contribution
+    attributes:
+      label: Willingness to implement or help test
+      description: Optional. Mention whether you want to implement this or help validate it.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and the roadmap first.
+          required: true

--- a/.github/ISSUE_TEMPLATE/support.yml
+++ b/.github/ISSUE_TEMPLATE/support.yml
@@ -1,0 +1,88 @@
+name: Support / setup help
+description: Ask for help configuring, running, or understanding yoink
+title: "[support] "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for setup questions, troubleshooting, or understanding how yoink works.
+
+        If you already know something is broken, use the bug report form instead. Please sanitize logs and config snippets before posting them.
+  - type: dropdown
+    id: topic
+    attributes:
+      label: Topic
+      options:
+        - Installation
+        - Configuration
+        - Providers
+        - SoulSeek/slskd
+        - Import/library organization
+        - Building from source
+        - Other
+    validations:
+      required: true
+  - type: dropdown
+    id: install_method
+    attributes:
+      label: Install method
+      options:
+        - Docker / Compose
+        - From source
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: yoink version / commit / image tag
+      placeholder: main@abcdef1
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Relevant environment details
+      description: Optional. Include OS, browser, reverse proxy, storage path shape, or other useful context.
+      placeholder: |
+        OS:
+        Browser:
+        Reverse proxy:
+        Storage path layout:
+  - type: textarea
+    id: provider_config
+    attributes:
+      label: Relevant provider configuration summary
+      description: Optional. Summarize the providers or integrations involved without posting secrets.
+      placeholder: |
+        Tidal enabled:
+        Deezer enabled:
+        MusicBrainz enabled:
+        SoulSeek/slskd enabled:
+  - type: textarea
+    id: goal
+    attributes:
+      label: What are you trying to do?
+    validations:
+      required: true
+  - type: textarea
+    id: blocked
+    attributes:
+      label: What happened instead / where are you blocked?
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Logs / screenshots / error messages
+      description: Optional. Paste sanitized logs or errors here.
+      render: shell
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I reviewed the README and setup docs first.
+          required: true
+        - label: I removed or redacted secrets from logs and config snippets.
+          required: true


### PR DESCRIPTION
## Summary
- Added a bug report issue template with required reproduction details, environment context, logs, and confirmation checkboxes.
- Added feature request and support/help templates to route user submissions into the right format.
- Enabled blank issues in the repository issue template config.

## Testing
- Not run (documentation/config-only change).
- Verified the new files are present under `.github/ISSUE_TEMPLATE/` and the YAML structure matches GitHub issue template format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced structured GitHub issue templates for bug reports, feature requests, and support inquiries with required fields to streamline issue submissions and ensure consistent information collection.
  * Enabled blank issue creation in the issue submission interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->