### PR TITLE
fix: sanitize path-like artist tags during local library scan (#23)

### DIFF
--- a/crates/yoink-server/src/services/library/import/shared.rs
+++ b/crates/yoink-server/src/services/library/import/shared.rs
@@ -162,6 +162,90 @@ mod tests {
         assert_eq!(discovered.discovered_year.as_deref(), Some("2005"));
     }
 
+    // ── Regression: issue #23 ─────────────────────────────────────────
+    // Some ripping tools write the relative folder path (e.g. "Artist1/Album1")
+    // into the ALBUMARTIST or ARTIST tag instead of just the artist name. Yoink
+    // should detect this and prefer the folder-derived artist name so that both
+    // albums end up under one artist, not two separate "Artist1/AlbumN" artists.
+
+    #[test]
+    fn summarize_album_sanitizes_path_like_artist_tag() {
+        let root = Path::new("/music");
+        let album_dir = PathBuf::from("/music/Artist1/Album1");
+        let files = vec![ScannedAudioFile {
+            absolute_path: album_dir.join("01 - Track.mp3"),
+            embedded: EmbeddedTrackMetadata {
+                album_artist: Some("Artist1/Album1".to_string()),
+                album_title: Some("Album1".to_string()),
+                ..EmbeddedTrackMetadata::default()
+            },
+        }];
+
+        let discovered = summarize_discovered_album(root, album_dir, files);
+
+        assert_eq!(discovered.discovered_artist, "Artist1");
+        assert_eq!(discovered.discovered_album, "Album1");
+    }
+
+    #[test]
+    fn summarize_album_sanitizes_backslash_path_like_artist_tag() {
+        let root = Path::new("/music");
+        let album_dir = PathBuf::from("/music/Artist1/Album2");
+        let files = vec![ScannedAudioFile {
+            absolute_path: album_dir.join("01 - Track.mp3"),
+            embedded: EmbeddedTrackMetadata {
+                album_artist: Some("Artist1\\Album2".to_string()),
+                album_title: Some("Album2".to_string()),
+                ..EmbeddedTrackMetadata::default()
+            },
+        }];
+
+        let discovered = summarize_discovered_album(root, album_dir, files);
+
+        assert_eq!(discovered.discovered_artist, "Artist1");
+    }
+
+    #[test]
+    fn summarize_album_keeps_valid_artist_tag_without_path_separators() {
+        let root = Path::new("/music");
+        let album_dir = PathBuf::from("/music/Path Artist/Path Album");
+        let files = vec![ScannedAudioFile {
+            absolute_path: album_dir.join("01 - Track.mp3"),
+            embedded: EmbeddedTrackMetadata {
+                album_artist: Some("Tagged Artist".to_string()),
+                album_title: Some("Tagged Album".to_string()),
+                ..EmbeddedTrackMetadata::default()
+            },
+        }];
+
+        let discovered = summarize_discovered_album(root, album_dir, files);
+
+        // A normal tag without path separators must be kept as-is
+        assert_eq!(discovered.discovered_artist, "Tagged Artist");
+    }
+
+    #[test]
+    fn summarize_album_path_like_tag_at_root_level_keeps_embedded_value() {
+        // When an album sits directly under the music root (no artist subfolder),
+        // there is no folder hint to fall back to. Prefer the embedded tag value
+        // over "Unknown Artist" even though it looks like a path.
+        let root = Path::new("/music");
+        let album_dir = PathBuf::from("/music/Album1");
+        let files = vec![ScannedAudioFile {
+            absolute_path: album_dir.join("01 - Track.mp3"),
+            embedded: EmbeddedTrackMetadata {
+                album_artist: Some("Artist1/Album1".to_string()),
+                album_title: Some("Album1".to_string()),
+                ..EmbeddedTrackMetadata::default()
+            },
+        }];
+
+        let discovered = summarize_discovered_album(root, album_dir, files);
+
+        // No parent-folder hint available, so fall back to the embedded value
+        assert_eq!(discovered.discovered_artist, "Artist1/Album1");
+    }
+    
     #[test]
     fn build_candidates_rejects_unrelated_partial_match() {
         let now = chrono::Utc::now();

--- a/crates/yoink-server/src/services/library/import/shared/discover.rs
+++ b/crates/yoink-server/src/services/library/import/shared/discover.rs
@@ -71,9 +71,9 @@ pub(super) fn summarize_discovered_album(
     // artist tag instead of just the artist name. When the embedded artist looks
     // like a path, prefer the folder-derived hint so that all albums under the
     // same artist directory share the correct, consistent artist name.
-    let discovered_artist = match embedded_artist {
-        Some(ref name) if name.contains('/') || name.contains('\\') => {
-            path_hint.artist.clone().or(embedded_artist)
+     let discovered_artist = match embedded_artist {
+        Some(name) if name.contains('/') || name.contains('\\') => {
+            path_hint.artist.clone().or(Some(name))
         }
         other => other.or(path_hint.artist.clone()),
     }

--- a/crates/yoink-server/src/services/library/import/shared/discover.rs
+++ b/crates/yoink-server/src/services/library/import/shared/discover.rs
@@ -55,7 +55,7 @@ pub(super) fn summarize_discovered_album(
     let relative_path = display_relative_path(root_path, &album_dir);
     let path_hint = path_metadata_hint(root_path, &album_dir);
 
-    let discovered_artist = most_common_string(
+    let embedded_artist = most_common_string(
         files
             .iter()
             .filter_map(|file| {
@@ -65,8 +65,18 @@ pub(super) fn summarize_discovered_album(
                     .or(file.embedded.track_artist.as_deref())
             })
             .collect(),
-    )
-    .or(path_hint.artist)
+    );
+
+    // Some ripping tools write the folder path (e.g. "Artist/Album") into the
+    // artist tag instead of just the artist name. When the embedded artist looks
+    // like a path, prefer the folder-derived hint so that all albums under the
+    // same artist directory share the correct, consistent artist name.
+    let discovered_artist = match embedded_artist {
+        Some(ref name) if name.contains('/') || name.contains('\\') => {
+            path_hint.artist.clone().or(embedded_artist)
+        }
+        other => other.or(path_hint.artist.clone()),
+    }
     .unwrap_or_else(|| "Unknown Artist".to_string());
 
     let discovered_album = most_common_string(


### PR DESCRIPTION
Fixes #23

   Some ripping tools write the relative folder path (e.g. `Artist1/Album1`)
   into the `ALBUMARTIST` tag instead of just the artist name. This caused
   Yoink to create a separate artist for every album when the artist didn't
   already exist in the database.

   **Root cause:** `summarize_discovered_album` trusted the embedded tag
   unconditionally. When the tag contained a path separator, the fuzzy
   matcher couldn't connect it to an existing artist entry, so a new artist
   was created per album.

   **Fix:** If the embedded artist tag contains `/` or `\`, prefer the
   parent-folder-derived name instead. The embedded value is kept as a
   fallback only when no folder hint is available (album at root level).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved metadata parsing to sanitise path-like embedded album artist values (forward/backward slashes) and prefer folder-derived artist/album when appropriate, while preserving valid tag values.

* **Tests**
  * Added regression tests covering path-like and space-containing embedded metadata cases, and root-folder behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->