### PR TITLE
fix(tidal): add lossless manifest support

### DIFF
--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -43,6 +43,18 @@ services:
       - .env.docker
     restart: always
 
+  hifi-api:
+    image: ghcr.io/binimum/hifi-api:main
+    container_name: hifi-api
+    restart: unless-stopped
+    environment:
+      - PUID=1000
+      - PGID=1000
+    env_file:
+      - .env.hifi
+    ports:
+      - 3005:8000
+
 volumes:
   yoink-data:
   postgres-data:

--- a/crates/yoink-server/src/main.rs
+++ b/crates/yoink-server/src/main.rs
@@ -67,10 +67,6 @@ async fn main() -> color_eyre::Result<()> {
     dotenvy::dotenv().ok();
     let app_config = AppConfig::from_env()?;
 
-    //     .unwrap_or_else(|err| {
-    //     panic!("Failed to parse configuration from environment: {err}");
-    // });
-
     init_logging(&app_config.log_format);
 
     let music_root = app_config.music_root_path();

--- a/crates/yoink-server/src/providers/tidal/manifest.rs
+++ b/crates/yoink-server/src/providers/tidal/manifest.rs
@@ -99,6 +99,18 @@ pub(crate) fn extract_download_payload(
     }
 }
 
+/// Parse a raw DASH MPD document into downloadable segment URLs.
+pub(crate) fn extract_dash_download_payload(xml: &str) -> Result<PlaybackInfo, ProviderError> {
+    if let Ok(urls) = extract_dash_segment_urls(xml)
+        && !urls.is_empty()
+    {
+        return Ok(PlaybackInfo::SegmentUrls(urls));
+    }
+    extract_dash_base_url(xml)
+        .map(PlaybackInfo::DirectUrl)
+        .map_err(ProviderError::from)
+}
+
 /// Parse a DASH MPD document and resolve all segment URLs from the
 /// highest-bandwidth audio `Representation`.
 ///
@@ -387,47 +399,4 @@ fn extract_dash_base_url(xml: &str) -> Result<String, ManifestError> {
         error: "no absolute URL found in DASH manifest",
     }
     .fail()
-}
-
-/// Produce a compact, single-line summary of a playback manifest for
-/// structured log output (element counts, byte size, MIME type).
-pub(crate) fn summarize_manifest_for_logs(playback: &HifiPlaybackData) -> String {
-    let decoded =
-        match base64::engine::general_purpose::STANDARD.decode(playback.manifest.as_bytes()) {
-            Ok(bytes) => bytes,
-            Err(err) => return format!("decode_error={err}"),
-        };
-
-    if playback.manifest_mime_type != "application/dash+xml" {
-        return format!(
-            "mime_type={}, decoded_bytes={}",
-            playback.manifest_mime_type,
-            decoded.len()
-        );
-    }
-
-    let xml = match String::from_utf8(decoded) {
-        Ok(xml) => xml,
-        Err(err) => return format!("dash_utf8_error={err}"),
-    };
-
-    let base_url_count = xml.matches("<BaseURL").count();
-    let representation_count = xml.matches("<Representation").count();
-    let adaptation_set_count = xml.matches("<AdaptationSet").count();
-    let segment_template_count = xml.matches("<SegmentTemplate").count();
-    let segment_base_count = xml.matches("<SegmentBase").count();
-    let segment_list_count = xml.matches("<SegmentList").count();
-    let content_protection_count = xml.matches("<ContentProtection").count();
-
-    format!(
-        "mime_type=application/dash+xml, xml_bytes={}, base_url={}, representation={}, adaptation_set={}, segment_template={}, segment_base={}, segment_list={}, content_protection={}",
-        xml.len(),
-        base_url_count,
-        representation_count,
-        adaptation_set_count,
-        segment_template_count,
-        segment_base_count,
-        segment_list_count,
-        content_protection_count
-    )
 }

--- a/crates/yoink-server/src/providers/tidal/mod.rs
+++ b/crates/yoink-server/src/providers/tidal/mod.rs
@@ -14,7 +14,7 @@ use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use async_trait::async_trait;
 use tokio::sync::RwLock;
-use tracing::warn;
+use tracing::debug;
 
 use crate::{
     db::{provider::Provider, quality::Quality},
@@ -24,7 +24,7 @@ use crate::{
 use self::{
     api::hifi_get_json,
     instances::InstanceCache,
-    manifest::{extract_download_payload, summarize_manifest_for_logs},
+    manifest::{extract_dash_download_payload, extract_download_payload},
     models::*,
 };
 use super::{
@@ -358,7 +358,7 @@ impl DownloadSource for TidalProvider {
     }
 
     fn requires_linked_provider(&self) -> bool {
-        false
+        true
     }
 
     async fn resolve_by_id(
@@ -376,6 +376,12 @@ impl DownloadSource for TidalProvider {
         // FIXME this will only resolve the first track ID
         let external_track_id = &external_track_ids[0];
 
+        if matches!(quality, Quality::Lossless | Quality::HiRes) {
+            return self
+                .resolve_lossless_by_track_manifest(external_track_id, quality)
+                .await;
+        }
+
         let quality_str = quality.as_str().to_string();
         let playback = self
             .hifi_get::<HifiPlaybackResponse>(
@@ -387,35 +393,7 @@ impl DownloadSource for TidalProvider {
             )
             .await?;
 
-        match extract_download_payload(&playback.data) {
-            Ok(payload) => Ok(payload),
-            Err(err)
-                if playback.data.manifest_mime_type == "application/dash+xml"
-                    && *quality == Quality::HiRes =>
-            {
-                let dash_summary = summarize_manifest_for_logs(&playback.data);
-                warn!(
-                    track_id = external_track_id,
-                    error = %err,
-                    manifest_summary = %dash_summary,
-                    "HI_RES DASH manifest unsupported, falling back to LOSSLESS"
-                );
-
-                // Retry with lossless
-                let fallback_playback = self
-                    .hifi_get::<HifiPlaybackResponse>(
-                        "/track/",
-                        vec![
-                            ("id".to_string(), external_track_id.to_string()),
-                            ("quality".to_string(), "LOSSLESS".to_string()),
-                        ],
-                    )
-                    .await?;
-
-                extract_download_payload(&fallback_playback.data)
-            }
-            Err(err) => Err(err),
-        }
+        extract_download_payload(&playback.data)
     }
 
     async fn resolve_by_metadata(
@@ -428,5 +406,83 @@ impl DownloadSource for TidalProvider {
             operation: "resolve_by_metadata".to_string(),
         }
         .fail()
+    }
+}
+
+impl TidalProvider {
+    async fn resolve_lossless_by_track_manifest(
+        &self,
+        external_track_id: &str,
+        quality: &Quality,
+    ) -> Result<PlaybackInfo, ProviderError> {
+        let formats = match quality {
+            Quality::HiRes => ["FLAC_HIRES", "FLAC"].as_slice(),
+            Quality::Lossless => ["FLAC"].as_slice(),
+            Quality::High | Quality::Low => unreachable!("only lossless qualities use manifests"),
+        };
+        let mut query = vec![
+            ("id".to_string(), external_track_id.to_string()),
+            ("adaptive".to_string(), "true".to_string()),
+            ("manifestType".to_string(), "MPEG_DASH".to_string()),
+            ("uriScheme".to_string(), "HTTPS".to_string()),
+            ("usage".to_string(), "PLAYBACK".to_string()),
+        ];
+        query.extend(
+            formats
+                .iter()
+                .map(|format| ("formats".to_string(), (*format).to_string())),
+        );
+
+        let response = self
+            .hifi_get::<HifiTrackManifestsResponse>("/trackManifests/", query)
+            .await?;
+        let attributes = response.data.data.attributes;
+        debug!(
+            track_id = external_track_id,
+            requested_quality = %quality,
+            formats = ?attributes.formats,
+            "Resolved Tidal track manifest"
+        );
+
+        if attributes
+            .formats
+            .iter()
+            .all(|format| !format.starts_with("FLAC"))
+        {
+            return Err(ProviderError::InvalidResponse {
+                provider: Provider::Tidal,
+                reason: format!(
+                    "track {external_track_id} requested {quality}, but trackManifests returned formats {:?}",
+                    attributes.formats,
+                ),
+            });
+        }
+
+        let manifest_xml = self
+            .http
+            .get(&attributes.uri)
+            .timeout(Duration::from_secs(20))
+            .send()
+            .await
+            .map_err(|source| ProviderError::Reqwest {
+                provider: Provider::Tidal,
+                operation: "track manifest request".to_string(),
+                source,
+            })?
+            .error_for_status()
+            .map_err(|err| ProviderError::Http {
+                provider: Provider::Tidal,
+                operation: "track manifest status".to_string(),
+                error: err.to_string(),
+            })?
+            .text()
+            .await
+            .map_err(|source| ProviderError::Reqwest {
+                provider: Provider::Tidal,
+                operation: "track manifest body".to_string(),
+                source,
+            })?;
+
+        extract_dash_download_payload(&manifest_xml)
     }
 }

--- a/crates/yoink-server/src/providers/tidal/models.rs
+++ b/crates/yoink-server/src/providers/tidal/models.rs
@@ -156,7 +156,7 @@ pub(crate) struct HifiSearchTrack {
     pub artists: Vec<HifiAlbumArtist>,
     /// Album this track belongs to.
     pub album: Option<HifiSearchTrackAlbum>,
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     #[serde(flatten)]
     pub extra: std::collections::HashMap<String, serde_json::Value>,
 }
@@ -177,17 +177,62 @@ pub(crate) struct HifiPlaybackResponse {
     pub data: HifiPlaybackData,
 }
 
+/// Response from the newer `/trackManifests/` endpoint.
+#[derive(Debug, Deserialize)]
+pub(crate) struct HifiTrackManifestsResponse {
+    pub data: HifiTrackManifestsData,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct HifiTrackManifestsData {
+    pub data: HifiTrackManifestResource,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct HifiTrackManifestResource {
+    pub attributes: HifiTrackManifestAttributes,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct HifiTrackManifestAttributes {
+    pub uri: String,
+    #[serde(default)]
+    pub formats: Vec<String>,
+    #[expect(dead_code)]
+    pub hash: Option<String>,
+}
+
 /// Playback data containing a base64-encoded manifest and its MIME type.
 #[derive(Debug, Deserialize)]
 pub(crate) struct HifiPlaybackData {
+    #[expect(dead_code)]
+    #[serde(rename = "trackId")]
+    pub track_id: Option<i64>,
+    #[expect(dead_code)]
+    #[serde(rename = "audioQuality")]
+    pub audio_quality: Option<String>,
     #[serde(rename = "manifestMimeType")]
     pub manifest_mime_type: String,
     pub manifest: String,
+    #[expect(dead_code)]
+    #[serde(rename = "bitDepth")]
+    pub bit_depth: Option<u32>,
+    #[expect(dead_code)]
+    #[serde(rename = "sampleRate")]
+    pub sample_rate: Option<u32>,
 }
 
 /// Decoded BTS manifest (`application/vnd.tidal.bts`) containing direct URLs.
 #[derive(Debug, Deserialize)]
 pub(crate) struct BtsManifest {
+    #[expect(dead_code)]
+    #[serde(rename = "mimeType")]
+    pub mime_type: Option<String>,
+    #[expect(dead_code)]
+    pub codecs: Option<String>,
+    #[expect(dead_code)]
+    #[serde(rename = "encryptionType")]
+    pub encryption_type: Option<String>,
     pub urls: Vec<String>,
 }
 


### PR DESCRIPTION
Resolve lossless and hi-res Tidal tracks via /trackManifests/ and
parse DASH manifests into segment URLs using
extract_dash_download_payload.
Introduce resolve_lossless_by_track_manifest and model types for the
trackManifests response. Replace manifest summarizer with debug logs
and mark unused fields with #[expect(dead_code)]. Also require a linked
provider for Tidal downloads and add a local hifi-api service to
compose.dev.yaml for development.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced Tidal support for lossless and hi-res audio quality through improved playback manifest resolution

* **Chores**
  * Added hifi-api service to development environment configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->