### PR TITLE
feat: add interactive soulseek DLs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1183,6 +1183,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "deunicode"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2303,7 +2309,7 @@ dependencies = [
 
 [[package]]
 name = "migration"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "sea-orm-migration",
  "tokio",
@@ -5110,7 +5116,7 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoink-server"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "argon2",
@@ -5121,6 +5127,7 @@ dependencies = [
  "clap",
  "color-eyre",
  "cookie",
+ "deunicode",
  "dotenvy",
  "envious",
  "governor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ chrono = { version = "0.4", features = ["clock", "serde"] }
 clap = { version = "4", features = ["derive", "env"] }
 color-eyre = "0.6.5"
 cookie = "0.18"
+deunicode = "1"
 dotenvy = "0.15.7"
 envious = "0.3.0"
 governor = "0.10"

--- a/crates/yoink-server/Cargo.toml
+++ b/crates/yoink-server/Cargo.toml
@@ -18,6 +18,7 @@ chrono.workspace             = true
 clap.workspace               = true
 color-eyre.workspace         = true
 cookie.workspace             = true
+deunicode.workspace          = true
 dotenvy.workspace            = true
 envious.workspace            = true
 governor.workspace           = true

--- a/crates/yoink-server/src/providers/mod.rs
+++ b/crates/yoink-server/src/providers/mod.rs
@@ -286,6 +286,67 @@ pub(crate) trait LinkedTrackResolver: Send + Sync {
     ) -> Result<PlaybackInfo, ProviderError>;
 }
 
+/// A single file offered by a peer, surfaced for manual (interactive) search
+/// so the user can override automatic candidate selection.
+#[derive(Debug, Clone, serde::Serialize, utoipa::ToSchema)]
+pub(crate) struct ManualSearchCandidate {
+    pub username: String,
+    pub filename: String,
+    pub size: i64,
+    pub length_secs: Option<u32>,
+    pub bit_rate: Option<u32>,
+    pub extension: Option<String>,
+    /// The automatic matcher's score for this file.
+    pub score: i32,
+    /// Whether the automatic matcher would consider this file at all.
+    pub plausible: bool,
+    pub has_free_upload_slot: bool,
+    pub queue_length: u32,
+}
+
+/// A user-chosen file to download, bypassing automatic candidate selection.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
+pub(crate) struct ManualDownloadSelection {
+    pub username: String,
+    pub filename: String,
+    pub size: i64,
+}
+
+/// One file inside a peer's album folder.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
+pub(crate) struct ManualAlbumFile {
+    pub filename: String,
+    pub size: i64,
+    pub length_secs: Option<u32>,
+    pub bit_rate: Option<u32>,
+    pub extension: Option<String>,
+}
+
+/// A peer's album folder surfaced for manual (interactive) album search.
+#[derive(Debug, Clone, serde::Serialize, utoipa::ToSchema)]
+pub(crate) struct ManualAlbumCandidate {
+    pub username: String,
+    pub folder: String,
+    pub files: Vec<ManualAlbumFile>,
+    /// How many of the album's tracks the automatic matcher can pair with a
+    /// file in this folder.
+    pub matched_tracks: u32,
+    pub total_size: i64,
+    pub score: i32,
+    pub has_free_upload_slot: bool,
+    pub queue_length: u32,
+}
+
+/// A user-chosen album folder to download, bypassing automatic selection.
+/// Carries the file listing the user saw so the job doesn't have to search
+/// again.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
+pub(crate) struct ManualAlbumSelection {
+    pub username: String,
+    pub folder: String,
+    pub files: Vec<ManualAlbumFile>,
+}
+
 /// Resolves playback by searching with locally stored track metadata.
 #[async_trait]
 pub(crate) trait SearchTrackResolver: Send + Sync {
@@ -297,6 +358,56 @@ pub(crate) trait SearchTrackResolver: Send + Sync {
         metadata: &DownloadTrackContext,
         quality: &Quality,
     ) -> Result<PlaybackInfo, ProviderError>;
+
+    /// List every candidate file the search surfaces, scored but unfiltered,
+    /// for the user to choose from manually.
+    async fn manual_search(
+        &self,
+        _metadata: &DownloadTrackContext,
+        _quality: &Quality,
+    ) -> Result<Vec<ManualSearchCandidate>, ProviderError> {
+        Err(ProviderError::NotSupported {
+            provider: self.id(),
+            operation: "manual_search".to_string(),
+        })
+    }
+
+    /// Download a specific user-chosen file, bypassing candidate selection.
+    async fn fetch_file(
+        &self,
+        _selection: &ManualDownloadSelection,
+    ) -> Result<PlaybackInfo, ProviderError> {
+        Err(ProviderError::NotSupported {
+            provider: self.id(),
+            operation: "fetch_file".to_string(),
+        })
+    }
+
+    /// List candidate album folders for an album's tracks, best-matched
+    /// first, for the user to choose from manually.
+    async fn manual_album_search(
+        &self,
+        _tracks: &[DownloadTrackContext],
+        _quality: &Quality,
+    ) -> Result<Vec<ManualAlbumCandidate>, ProviderError> {
+        Err(ProviderError::NotSupported {
+            provider: self.id(),
+            operation: "manual_album_search".to_string(),
+        })
+    }
+
+    /// Download one track's file out of a user-chosen album folder.
+    async fn fetch_album_file(
+        &self,
+        _selection: &ManualAlbumSelection,
+        _metadata: &DownloadTrackContext,
+        _quality: &Quality,
+    ) -> Result<PlaybackInfo, ProviderError> {
+        Err(ProviderError::NotSupported {
+            provider: self.id(),
+            operation: "fetch_album_file".to_string(),
+        })
+    }
 }
 
 /// An enabled download source and the lookup strategy it supports.

--- a/crates/yoink-server/src/providers/mod.rs
+++ b/crates/yoink-server/src/providers/mod.rs
@@ -55,6 +55,8 @@ pub(crate) enum ProviderError {
     Unavailable { provider: Provider, reason: String },
     #[snafu(display("{provider} invalid response: {reason}"))]
     InvalidResponse { provider: Provider, reason: String },
+    #[snafu(display("{provider} invalid manual selection: {reason}"))]
+    InvalidSelection { provider: Provider, reason: String },
 
     #[snafu(display("{provider} operation not supported: {operation}"))]
     NotSupported {
@@ -328,9 +330,12 @@ pub(crate) struct ManualAlbumCandidate {
     pub username: String,
     pub folder: String,
     pub files: Vec<ManualAlbumFile>,
-    /// How many of the album's tracks the automatic matcher can pair with a
-    /// file in this folder.
+    /// How many of the album's tracks strictly title-match a file in this
+    /// folder.
     pub matched_tracks: u32,
+    /// How many of the album's tracks a manual download would actually fetch
+    /// from this folder (strict matches plus track-number fallback).
+    pub pairable_tracks: u32,
     pub total_size: i64,
     pub score: i32,
     pub has_free_upload_slot: bool,

--- a/crates/yoink-server/src/providers/soulseek/matching.rs
+++ b/crates/yoink-server/src/providers/soulseek/matching.rs
@@ -9,7 +9,12 @@ use super::{
     models::{SearchFile, SearchResponse},
     util::{detect_audio_extension, normalize, normalized_parent_dir, parse_track_number},
 };
-use crate::{db::quality::Quality, providers::DownloadTrackContext};
+use crate::{
+    db::quality::Quality,
+    providers::{
+        DownloadTrackContext, ManualAlbumCandidate, ManualAlbumFile, ManualSearchCandidate,
+    },
+};
 
 // ── Types ───────────────────────────────────────────────────────────
 
@@ -19,6 +24,8 @@ pub(crate) struct Candidate {
     pub filename: String,
     pub size: i64,
     pub score: i32,
+    /// Duration advertised in the search result, used to verify the download.
+    pub reported_length: Option<u32>,
 }
 
 #[derive(Debug, Clone)]
@@ -29,44 +36,140 @@ struct AlbumBundleFile {
     extension: String,
     track_number: Option<u32>,
     length: Option<u32>,
+    bit_rate: Option<u32>,
 }
 
 // ── Single-track scoring ────────────────────────────────────────────
 
-pub(crate) fn pick_best_candidate(
+/// Reject single-track candidates whose score falls below this floor; a
+/// negative score means nothing beyond bare title plausibility matched.
+const MIN_SINGLE_TRACK_SCORE: i32 = 0;
+
+/// Score all plausible files across responses and return them best-first, so
+/// callers can fall back to the next candidate when a download fails.
+pub(crate) fn rank_candidates(
     responses: &[SearchResponse],
     ctx: &DownloadTrackContext,
     quality: &Quality,
-) -> Option<Candidate> {
+) -> Vec<Candidate> {
     let artist = normalize(&ctx.artist_name);
     let album = normalize(&ctx.album_title);
     let title = normalize(&ctx.track_title);
 
-    let mut best: Option<Candidate> = None;
+    let mut seen: HashSet<(String, String)> = HashSet::new();
+    let mut candidates = Vec::new();
+    let (mut non_audio, mut implausible, mut low_score) = (0usize, 0usize, 0usize);
+    let mut rejected_examples: Vec<String> = Vec::new();
 
     for resp in responses {
         for file in &resp.files {
             if detect_audio_extension(file.extension.as_deref(), &file.filename).is_none() {
+                non_audio += 1;
                 continue;
             }
             if !is_plausible_match(&file.filename, file.length, ctx) {
+                implausible += 1;
+                if rejected_examples.len() < 3 {
+                    rejected_examples.push(format!("{} len={:?}", file.filename, file.length));
+                }
                 continue;
             }
 
-            let score = score_file(file, &artist, &album, &title, ctx, quality);
-
-            if best.as_ref().is_none_or(|b| score > b.score) {
-                best = Some(Candidate {
-                    username: resp.username.clone(),
-                    filename: file.filename.clone(),
-                    size: file.size,
-                    score,
-                });
+            let score = score_file(file, &artist, &album, &title, ctx, quality) + peer_score(resp);
+            if score < MIN_SINGLE_TRACK_SCORE {
+                low_score += 1;
+                continue;
             }
+            if !seen.insert((resp.username.clone(), file.filename.clone())) {
+                continue;
+            }
+
+            candidates.push(Candidate {
+                username: resp.username.clone(),
+                filename: file.filename.clone(),
+                size: file.size,
+                score,
+                reported_length: file.length,
+            });
         }
     }
 
-    best
+    if candidates.is_empty() {
+        tracing::debug!(
+            track = ctx.track_title,
+            non_audio,
+            implausible,
+            low_score,
+            examples = ?rejected_examples,
+            "SoulSeek ranking rejected every file"
+        );
+    }
+
+    candidates.sort_by_key(|candidate| std::cmp::Reverse(candidate.score));
+    candidates
+}
+
+/// Score every audio file across responses without filtering, for manual
+/// (interactive) search. Plausible files sort first, then by score.
+pub(crate) fn rank_all_files(
+    responses: &[SearchResponse],
+    ctx: &DownloadTrackContext,
+    quality: &Quality,
+) -> Vec<ManualSearchCandidate> {
+    let artist = normalize(&ctx.artist_name);
+    let album = normalize(&ctx.album_title);
+    let title = normalize(&ctx.track_title);
+
+    let mut seen: HashSet<(String, String)> = HashSet::new();
+    let mut candidates = Vec::new();
+
+    for resp in responses {
+        for file in &resp.files {
+            let extension = detect_audio_extension(file.extension.as_deref(), &file.filename);
+            if extension.is_none() {
+                continue;
+            }
+            if !seen.insert((resp.username.clone(), file.filename.clone())) {
+                continue;
+            }
+
+            candidates.push(ManualSearchCandidate {
+                username: resp.username.clone(),
+                filename: file.filename.clone(),
+                size: file.size,
+                length_secs: file.length,
+                bit_rate: file.bit_rate,
+                extension,
+                score: score_file(file, &artist, &album, &title, ctx, quality) + peer_score(resp),
+                plausible: is_plausible_match(&file.filename, file.length, ctx),
+                has_free_upload_slot: resp.has_free_upload_slot,
+                queue_length: resp.queue_length,
+            });
+        }
+    }
+
+    candidates.sort_by_key(|candidate| {
+        (
+            std::cmp::Reverse(candidate.plausible),
+            std::cmp::Reverse(candidate.score),
+        )
+    });
+    candidates
+}
+
+/// Small bonus for peers likely to actually serve the file; kept minor so
+/// metadata quality still dominates ranking.
+fn peer_score(resp: &SearchResponse) -> i32 {
+    let mut score = 0i32;
+    if resp.has_free_upload_slot {
+        score += 6;
+    } else if resp.queue_length > 20 {
+        score -= 4;
+    }
+    if resp.upload_speed >= 1_000_000 {
+        score += 2;
+    }
+    score
 }
 
 fn score_file(
@@ -78,18 +181,14 @@ fn score_file(
     quality: &Quality,
 ) -> i32 {
     let filename = normalize(&file.filename);
+    let filename_tokens: HashSet<&str> = filename.split(' ').collect();
     let mut score = 0i32;
 
-    // Metadata matches
-    if !artist.is_empty() && filename.contains(artist) {
-        score += 45;
-    }
-    if !album.is_empty() && filename.contains(album) {
-        score += 20;
-    }
-    if !title.is_empty() && filename.contains(title) {
-        score += 60;
-    }
+    // Metadata matches: full credit for a contiguous match, partial credit
+    // when all tokens are present but interleaved with other text.
+    score += containment_score(&filename, &filename_tokens, artist, 45, 35);
+    score += containment_score(&filename, &filename_tokens, album, 20, 14);
+    score += containment_score(&filename, &filename_tokens, title, 60, 40);
 
     // Duration proximity
     if let Some(len) = file.length
@@ -120,6 +219,28 @@ fn score_file(
     score
 }
 
+fn containment_score(
+    filename: &str,
+    filename_tokens: &HashSet<&str>,
+    needle: &str,
+    contiguous: i32,
+    scattered: i32,
+) -> i32 {
+    if needle.is_empty() {
+        return 0;
+    }
+    if filename.contains(needle) {
+        return contiguous;
+    }
+    if needle
+        .split(' ')
+        .all(|token| filename_tokens.contains(token))
+    {
+        return scattered;
+    }
+    0
+}
+
 /// Reject files that only happen to contain the requested title as part of a
 /// different title. Loose names require both close duration and artist/album
 /// context; exact-compatible names can stand on their own.
@@ -138,29 +259,88 @@ fn is_plausible_match(
         .file_stem()
         .and_then(|value| value.to_str())
         .unwrap_or(filename);
-    let mut remaining = tokens(stem);
+    let stem_tokens = tokens(stem);
 
+    let mut remaining = stem_tokens.clone();
+    let mut missing = 0usize;
     for expected in &title_tokens {
-        let Some(position) = remaining.iter().position(|token| token == expected) else {
-            return false;
-        };
-        remaining.remove(position);
+        match remaining.iter().position(|token| token == expected) {
+            Some(position) => {
+                remaining.remove(position);
+            }
+            None => missing += 1,
+        }
+    }
+
+    // Space-insensitive fallback for joined/split words ("Skyhigh" vs
+    // "Sky High", "4 Ever" vs "4ever"): match the title against the stem with
+    // all spaces removed and keep what surrounds it as the leftover.
+    let compact_leftover = (missing > 0)
+        .then(|| {
+            let stem_compact = stem_tokens.concat();
+            let title_compact = title_tokens.concat();
+            stem_compact.find(&title_compact).map(|start| {
+                let mut leftover = stem_compact;
+                leftover.replace_range(start..start + title_compact.len(), "");
+                leftover
+            })
+        })
+        .flatten();
+
+    // Filenames often drop or vary one word of a longer title ("Pt" vs
+    // "Part"); forgive a single absent token, but such matches must clear the
+    // stricter context + duration gate below instead of standing on their own.
+    if compact_leftover.is_none() && (missing > 1 || (missing == 1 && title_tokens.len() < 3)) {
+        return false;
     }
 
     let artist_tokens = tokens(&ctx.artist_name);
     let album_tokens = tokens(&ctx.album_title);
-    let strong_title = remaining.iter().all(|token| {
-        token.chars().all(|c| c.is_ascii_digit())
-            || artist_tokens.contains(token)
-            || album_tokens.contains(token)
-            || TITLE_NOISE_TOKENS.contains(&token.as_str())
-    });
+
+    // Leftover markers of a different recording (instrumental, live, cover,
+    // ...) disqualify the file unless the request itself asks for that
+    // version. After a compact match the per-token leftover is meaningless,
+    // so check every stem token that is not part of the title instead.
+    let version_check_tokens: &[String] = if compact_leftover.is_some() {
+        &stem_tokens
+    } else {
+        &remaining
+    };
+    if version_check_tokens.iter().any(|token| {
+        WRONG_VERSION_TOKENS.contains(&token.as_str())
+            && !title_tokens.contains(token)
+            && !album_tokens.contains(token)
+    }) {
+        return false;
+    }
+
+    let strong_title = if missing == 0 {
+        remaining.iter().all(|token| {
+            token.chars().all(|c| c.is_ascii_digit())
+                || artist_tokens.contains(token)
+                || album_tokens.contains(token)
+                || TITLE_NOISE_TOKENS.contains(&token.as_str())
+        })
+    } else if let Some(leftover) = &compact_leftover {
+        compact_leftover_is_noise(leftover, &artist_tokens, &album_tokens)
+    } else {
+        false
+    };
 
     let duration_diff = candidate_duration
         .zip(ctx.duration_secs)
         .map(|(candidate, expected)| candidate.abs_diff(expected));
     if let (Some(diff), Some(expected)) = (duration_diff, ctx.duration_secs) {
-        let tolerance = 8.max(expected / 20);
+        // Provider durations can be well off for the same recording (megamix
+        // segment boundaries, pressing differences), so a strong title match
+        // gets a generous bound and relies on the score penalty instead. A
+        // weak match keeps the tight bound: there duration is the main
+        // defense against a different song.
+        let tolerance = if strong_title {
+            45.max(expected / 3)
+        } else {
+            8.max(expected / 20)
+        };
         if diff > tolerance {
             return false;
         }
@@ -177,6 +357,26 @@ fn is_plausible_match(
         || (!album_tokens.is_empty() && normalized_filename.contains(&normalize(&ctx.album_title)));
 
     has_context && duration_diff.is_some_and(|diff| diff <= 3)
+}
+
+/// After removing the title from the space-stripped stem, decide whether the
+/// leftover is only numbering/artist/album/noise — i.e. nothing hinting at a
+/// different song.
+fn compact_leftover_is_noise(
+    leftover: &str,
+    artist_tokens: &[String],
+    album_tokens: &[String],
+) -> bool {
+    let mut leftover = leftover.to_string();
+    for chunk in [artist_tokens.concat(), album_tokens.concat()] {
+        if !chunk.is_empty() {
+            leftover = leftover.replace(&chunk, "");
+        }
+    }
+    for token in TITLE_NOISE_TOKENS {
+        leftover = leftover.replace(token, "");
+    }
+    leftover.chars().all(|c| c.is_ascii_digit())
 }
 
 fn tokens(value: &str) -> Vec<String> {
@@ -196,7 +396,10 @@ const TITLE_NOISE_TOKENS: &[&str] = &[
     "clean",
     "edit",
     "explicit",
+    "feat",
+    "featuring",
     "flac",
+    "ft",
     "lossless",
     "master",
     "mix",
@@ -206,6 +409,31 @@ const TITLE_NOISE_TOKENS: &[&str] = &[
     "stereo",
     "track",
     "version",
+];
+
+/// Tokens that mark a different recording of the requested song. Their
+/// presence in leftover filename tokens rejects the candidate outright unless
+/// the requested title or album contains the token itself.
+const WRONG_VERSION_TOKENS: &[&str] = &[
+    "8d",
+    "acapella",
+    "acoustic",
+    "bootleg",
+    "cover",
+    "demo",
+    "instrumental",
+    "karaoke",
+    "live",
+    "mashup",
+    "medley",
+    "megamix",
+    "nightcore",
+    "remix",
+    "reverb",
+    "slowed",
+    "sped",
+    "tribute",
+    "unplugged",
 ];
 
 fn file_extension(file: &SearchFile) -> String {
@@ -229,41 +457,61 @@ fn extension_quality_score(ext: &str, quality: &Quality) -> i32 {
 
 // ── Album-bundle selection ──────────────────────────────────────────
 
-/// Try to find a complete album folder and pick the requested track from it.
-/// Returns `None` if no folder has at least `expected_tracks` audio files.
-pub(crate) fn pick_from_album_bundle(
+/// Find complete album folders and pick the requested track from each,
+/// returned best-first. Folders whose path mentions neither the artist nor
+/// the album are skipped: a track-count coincidence alone must not outrank
+/// single-file matches.
+pub(crate) fn rank_album_bundles(
     responses: &[SearchResponse],
     ctx: &DownloadTrackContext,
     quality: &Quality,
-) -> Option<Candidate> {
-    let expected_tracks = ctx.album_track_count.filter(|&n| n > 0)?;
+) -> Vec<Candidate> {
+    let Some(expected_tracks) = ctx.album_track_count.filter(|&n| n > 0) else {
+        return Vec::new();
+    };
 
+    let peer_scores: HashMap<&str, i32> = responses
+        .iter()
+        .map(|resp| (resp.username.as_str(), peer_score(resp)))
+        .collect();
     let bundles = group_files_into_bundles(responses);
 
     let artist = normalize(&ctx.artist_name);
     let album = normalize(&ctx.album_title);
 
-    bundles
+    let mut candidates: Vec<Candidate> = bundles
         .into_iter()
-        .filter(|(_, files, _)| count_unique_tracks(files) >= expected_tracks)
-        .filter_map(|(key, files, _)| {
+        .filter(|(_, files)| count_unique_tracks(files) >= expected_tracks)
+        .filter_map(|(key, files)| {
+            let parent_norm = normalize(&key.1);
+            let has_context = (!artist.is_empty() && parent_norm.contains(&artist))
+                || (!album.is_empty() && parent_norm.contains(&album));
+            if !has_context {
+                return None;
+            }
+
             let chosen = choose_track_from_bundle(&files, ctx, quality)?;
-            let bundle_score = score_bundle(&key.1, &artist, &album, &files, expected_tracks);
+            let bundle_score = score_bundle(&key.1, &artist, &album, &files, expected_tracks)
+                + peer_scores.get(key.0.as_str()).copied().unwrap_or(0);
             Some(Candidate {
                 username: chosen.username.clone(),
                 filename: chosen.filename.clone(),
                 size: chosen.size,
                 score: 10_000 + bundle_score,
+                reported_length: chosen.length,
             })
         })
-        .max_by_key(|candidate| candidate.score)
+        .collect();
+
+    candidates.sort_by_key(|candidate| std::cmp::Reverse(candidate.score));
+    candidates
 }
 
 type BundleKey = (String, String); // (username, parent_dir)
 
 fn group_files_into_bundles(
     responses: &[SearchResponse],
-) -> Vec<(BundleKey, Vec<AlbumBundleFile>, i32)> {
+) -> Vec<(BundleKey, Vec<AlbumBundleFile>)> {
     let mut map: HashMap<BundleKey, Vec<AlbumBundleFile>> = HashMap::new();
 
     for resp in responses {
@@ -286,11 +534,12 @@ fn group_files_into_bundles(
                     extension,
                     track_number: parse_track_number(&file.filename),
                     length: file.length,
+                    bit_rate: file.bit_rate,
                 });
         }
     }
 
-    map.into_iter().map(|(k, v)| (k, v, 0)).collect()
+    map.into_iter().collect()
 }
 
 fn count_unique_tracks(files: &[AlbumBundleFile]) -> usize {
@@ -326,26 +575,139 @@ fn score_bundle(
     score
 }
 
+/// Rank every album folder peers offered, best-matched first, for manual
+/// (interactive) album search. Unlike [`rank_album_bundles`] nothing is
+/// filtered out — the user decides.
+pub(crate) fn rank_album_folders(
+    responses: &[SearchResponse],
+    tracks: &[DownloadTrackContext],
+    quality: &Quality,
+) -> Vec<ManualAlbumCandidate> {
+    let Some(first) = tracks.first() else {
+        return Vec::new();
+    };
+    let artist = normalize(&first.artist_name);
+    let album = normalize(&first.album_title);
+    let expected_tracks = tracks.len();
+
+    let peers: HashMap<&str, &SearchResponse> = responses
+        .iter()
+        .map(|resp| (resp.username.as_str(), resp))
+        .collect();
+
+    let mut candidates: Vec<ManualAlbumCandidate> = group_files_into_bundles(responses)
+        .into_iter()
+        .map(|((username, folder), files)| {
+            let matched_tracks = tracks
+                .iter()
+                .filter(|ctx| pick_manual_bundle_file(&files, ctx, quality).is_some())
+                .count() as u32;
+            let peer = peers.get(username.as_str());
+            let score = score_bundle(&folder, &artist, &album, &files, expected_tracks)
+                + peer.map(|resp| peer_score(resp)).unwrap_or(0);
+
+            ManualAlbumCandidate {
+                username,
+                folder,
+                total_size: files.iter().map(|file| file.size).sum(),
+                files: files
+                    .into_iter()
+                    .map(|file| ManualAlbumFile {
+                        filename: file.filename,
+                        size: file.size,
+                        length_secs: file.length,
+                        bit_rate: file.bit_rate,
+                        extension: Some(file.extension),
+                    })
+                    .collect(),
+                matched_tracks,
+                score,
+                has_free_upload_slot: peer.is_some_and(|resp| resp.has_free_upload_slot),
+                queue_length: peer.map(|resp| resp.queue_length).unwrap_or(0),
+            }
+        })
+        .collect();
+
+    candidates.sort_by_key(|candidate| {
+        (
+            std::cmp::Reverse(candidate.matched_tracks),
+            std::cmp::Reverse(candidate.score),
+        )
+    });
+    candidates.truncate(50);
+    candidates
+}
+
+/// Pick the file for one track out of a user-chosen album folder. Falls back
+/// to a bare track-number match when no filename is plausible — the user
+/// vouched for the folder, so odd naming shouldn't block the download.
+pub(crate) fn choose_manual_album_file<'a>(
+    files: &'a [ManualAlbumFile],
+    username: &str,
+    ctx: &DownloadTrackContext,
+    quality: &Quality,
+) -> Option<&'a ManualAlbumFile> {
+    let bundle: Vec<AlbumBundleFile> = files
+        .iter()
+        .map(|file| AlbumBundleFile {
+            username: username.to_string(),
+            filename: file.filename.clone(),
+            size: file.size,
+            extension: file.extension.clone().unwrap_or_default(),
+            track_number: parse_track_number(&file.filename),
+            length: file.length_secs,
+            bit_rate: file.bit_rate,
+        })
+        .collect();
+
+    let chosen_filename =
+        pick_manual_bundle_file(&bundle, ctx, quality).map(|file| file.filename.clone())?;
+
+    files.iter().find(|file| file.filename == chosen_filename)
+}
+
+/// The pairing logic manual album downloads actually use: plausible match
+/// first, then a bare track-number fallback — the user vouched for the
+/// folder, so odd naming shouldn't block the download.
+fn pick_manual_bundle_file<'a>(
+    files: &'a [AlbumBundleFile],
+    ctx: &DownloadTrackContext,
+    quality: &Quality,
+) -> Option<&'a AlbumBundleFile> {
+    choose_track_from_bundle(files, ctx, quality).or_else(|| {
+        ctx.track_number.and_then(|number| {
+            files
+                .iter()
+                .filter(|file| file.track_number == Some(number))
+                .max_by_key(|file| bundle_extension_quality_score(&file.extension, quality))
+        })
+    })
+}
+
 fn choose_track_from_bundle<'a>(
     files: &'a [AlbumBundleFile],
     ctx: &DownloadTrackContext,
     quality: &Quality,
 ) -> Option<&'a AlbumBundleFile> {
-    let require_track_number =
-        ctx.track_number.is_some() && files.iter().any(|file| file.track_number.is_some());
+    let plausible = |file: &&AlbumBundleFile| is_plausible_match(&file.filename, file.length, ctx);
 
+    if ctx.track_number.is_some() {
+        let numbered = files
+            .iter()
+            .filter(|file| file.track_number == ctx.track_number)
+            .filter(plausible)
+            .max_by_key(|file| bundle_extension_quality_score(&file.extension, quality));
+        if numbered.is_some() {
+            return numbered;
+        }
+    }
+
+    // Other pressings of the same album order tracks differently, so a title
+    // match at a different track number still beats no match at all.
     files
         .iter()
-        .filter(|file| !require_track_number || file.track_number == ctx.track_number)
-        .filter(|file| is_plausible_match(&file.filename, file.length, ctx))
-        .max_by_key(|file| {
-            let track_number_matches =
-                ctx.track_number.is_some() && ctx.track_number == file.track_number;
-            (
-                track_number_matches,
-                bundle_extension_quality_score(&file.extension, quality),
-            )
-        })
+        .filter(plausible)
+        .max_by_key(|file| bundle_extension_quality_score(&file.extension, quality))
 }
 
 // ── Quality scoring for bundle file selection ───────────────────────

--- a/crates/yoink-server/src/providers/soulseek/matching.rs
+++ b/crates/yoink-server/src/providers/soulseek/matching.rs
@@ -154,6 +154,7 @@ pub(crate) fn rank_all_files(
             std::cmp::Reverse(candidate.score),
         )
     });
+    candidates.truncate(50);
     candidates
 }
 
@@ -188,7 +189,19 @@ fn score_file(
     // when all tokens are present but interleaved with other text.
     score += containment_score(&filename, &filename_tokens, artist, 45, 35);
     score += containment_score(&filename, &filename_tokens, album, 20, 14);
-    score += containment_score(&filename, &filename_tokens, title, 60, 40);
+    let title_score = containment_score(&filename, &filename_tokens, title, 60, 40);
+    score += if title_score > 0 {
+        title_score
+    } else {
+        // Reduced credit when only the parenthetical-free core title matches
+        // ("Thinking of You (David Riva mix)" vs "03 - Thinking Of You").
+        let core = normalize(&strip_parentheticals(&ctx.track_title));
+        if core.is_empty() || core == title {
+            0
+        } else {
+            containment_score(&filename, &filename_tokens, &core, 40, 28)
+        }
+    };
 
     // Duration proximity
     if let Some(len) = file.length
@@ -249,11 +262,60 @@ fn is_plausible_match(
     candidate_duration: Option<u32>,
     ctx: &DownloadTrackContext,
 ) -> bool {
-    let title_tokens = tokens(&ctx.track_title);
-    if title_tokens.is_empty() {
+    let full_tokens = tokens(&ctx.track_title);
+    if full_tokens.is_empty() {
         return false;
     }
 
+    if title_match_is_plausible(
+        &full_tokens,
+        &full_tokens,
+        filename,
+        candidate_duration,
+        ctx,
+    ) {
+        return true;
+    }
+
+    // Catalog titles often carry mix credits the files drop ("Thinking of
+    // You (David Riva mix)" vs "03 - Thinking Of You"): retry with the
+    // parenthetical-free core title. The full title still governs which
+    // version markers are allowed.
+    let core_tokens = tokens(&strip_parentheticals(&ctx.track_title));
+    if !core_tokens.is_empty() && core_tokens.len() < full_tokens.len() {
+        return title_match_is_plausible(
+            &core_tokens,
+            &full_tokens,
+            filename,
+            candidate_duration,
+            ctx,
+        );
+    }
+    false
+}
+
+/// Remove `(...)` and `[...]` segments, keeping the surrounding text.
+fn strip_parentheticals(value: &str) -> String {
+    let mut out = String::new();
+    let mut depth = 0i32;
+    for c in value.chars() {
+        match c {
+            '(' | '[' => depth += 1,
+            ')' | ']' => depth = (depth - 1).max(0),
+            _ if depth == 0 => out.push(c),
+            _ => {}
+        }
+    }
+    out
+}
+
+fn title_match_is_plausible(
+    title_tokens: &[String],
+    requested_tokens: &[String],
+    filename: &str,
+    candidate_duration: Option<u32>,
+    ctx: &DownloadTrackContext,
+) -> bool {
     let normalized_path = filename.replace('\\', "/");
     let stem = Path::new(&normalized_path)
         .file_stem()
@@ -263,12 +325,9 @@ fn is_plausible_match(
 
     let mut remaining = stem_tokens.clone();
     let mut missing = 0usize;
-    for expected in &title_tokens {
-        match remaining.iter().position(|token| token == expected) {
-            Some(position) => {
-                remaining.remove(position);
-            }
-            None => missing += 1,
+    for expected in title_tokens {
+        if !take_token_match(&mut remaining, expected) {
+            missing += 1;
         }
     }
 
@@ -308,7 +367,7 @@ fn is_plausible_match(
     };
     if version_check_tokens.iter().any(|token| {
         WRONG_VERSION_TOKENS.contains(&token.as_str())
-            && !title_tokens.contains(token)
+            && !requested_tokens.contains(token)
             && !album_tokens.contains(token)
     }) {
         return false;
@@ -327,16 +386,30 @@ fn is_plausible_match(
         false
     };
 
+    let normalized_filename = normalize(filename);
+    let has_context = (!artist_tokens.is_empty()
+        && !is_unknown_artist(&ctx.artist_name)
+        && normalized_filename.contains(&normalize(&ctx.artist_name)))
+        || (!album_tokens.is_empty() && normalized_filename.contains(&normalize(&ctx.album_title)));
+
+    // Compilation-style "NN Original Artist - Title" naming: when the path
+    // vouches for the album or artist and a trailing segment holds exactly
+    // the title, trust it like a strong match — the unrecognized tokens are
+    // an artist credit, not a different song.
+    let trailing_title =
+        missing == 0 && has_context && trailing_segment_matches_title(stem, title_tokens);
+    let trusted_title = strong_title || trailing_title;
+
     let duration_diff = candidate_duration
         .zip(ctx.duration_secs)
         .map(|(candidate, expected)| candidate.abs_diff(expected));
     if let (Some(diff), Some(expected)) = (duration_diff, ctx.duration_secs) {
         // Provider durations can be well off for the same recording (megamix
-        // segment boundaries, pressing differences), so a strong title match
+        // segment boundaries, pressing differences), so a trusted title match
         // gets a generous bound and relies on the score penalty instead. A
         // weak match keeps the tight bound: there duration is the main
         // defense against a different song.
-        let tolerance = if strong_title {
+        let tolerance = if trusted_title {
             45.max(expected / 3)
         } else {
             8.max(expected / 20)
@@ -346,17 +419,64 @@ fn is_plausible_match(
         }
     }
 
-    if strong_title {
+    if trusted_title {
         return true;
     }
 
-    let normalized_filename = normalize(filename);
-    let has_context = (!artist_tokens.is_empty()
-        && !is_unknown_artist(&ctx.artist_name)
-        && normalized_filename.contains(&normalize(&ctx.artist_name)))
-        || (!album_tokens.is_empty() && normalized_filename.contains(&normalize(&ctx.album_title)));
-
     has_context && duration_diff.is_some_and(|diff| diff <= 3)
+}
+
+/// Match a title token against the candidate's tokens, removing the matched
+/// token. Falls back to jaro-winkler for word variations ("think" vs
+/// "thinking"); short tokens must match exactly.
+fn take_token_match(remaining: &mut Vec<String>, expected: &str) -> bool {
+    if let Some(position) = remaining.iter().position(|token| token == expected) {
+        remaining.remove(position);
+        return true;
+    }
+    if expected.len() < 4 {
+        return false;
+    }
+
+    // The length cap keeps prefix-extended words apart ("fire" vs
+    // "firewater" scores 0.89 on jaro-winkler alone).
+    let best = remaining
+        .iter()
+        .enumerate()
+        .filter(|(_, token)| token.len() >= 4 && token.len().abs_diff(expected.len()) <= 3)
+        .map(|(index, token)| (index, strsim::jaro_winkler(token, expected)))
+        .max_by(|a, b| a.1.total_cmp(&b.1));
+    if let Some((index, score)) = best
+        && score >= FUZZY_TOKEN_MIN
+    {
+        remaining.remove(index);
+        return true;
+    }
+    false
+}
+
+/// Minimum jaro-winkler similarity for a fuzzy token match. High enough that
+/// "night" vs "light" fails while "think" vs "thinking" passes.
+const FUZZY_TOKEN_MIN: f64 = 0.87;
+
+/// Whether the last `-`-separated segment of the stem contains the title
+/// (exact or fuzzy per token) with only digit/noise extras.
+fn trailing_segment_matches_title(stem: &str, title_tokens: &[String]) -> bool {
+    let last_segment = stem.rsplit('-').next().unwrap_or(stem);
+    let mut remaining = tokens(last_segment);
+    if remaining.is_empty() {
+        return false;
+    }
+
+    for expected in title_tokens {
+        if !take_token_match(&mut remaining, expected) {
+            return false;
+        }
+    }
+
+    remaining.iter().all(|token| {
+        token.chars().all(|c| c.is_ascii_digit()) || TITLE_NOISE_TOKENS.contains(&token.as_str())
+    })
 }
 
 /// After removing the title from the space-stripped stem, decide whether the
@@ -598,7 +718,16 @@ pub(crate) fn rank_album_folders(
     let mut candidates: Vec<ManualAlbumCandidate> = group_files_into_bundles(responses)
         .into_iter()
         .map(|((username, folder), files)| {
+            // Strict matching only: the bare track-number fallback in
+            // `pick_manual_bundle_file` is for after the user vouched for a
+            // folder, and would let unrelated numbered files inflate the
+            // count here.
             let matched_tracks = tracks
+                .iter()
+                .filter(|ctx| choose_track_from_bundle(&files, ctx, quality).is_some())
+                .count() as u32;
+            // What a manual download of this folder would actually fetch.
+            let pairable_tracks = tracks
                 .iter()
                 .filter(|ctx| pick_manual_bundle_file(&files, ctx, quality).is_some())
                 .count() as u32;
@@ -621,6 +750,7 @@ pub(crate) fn rank_album_folders(
                     })
                     .collect(),
                 matched_tracks,
+                pairable_tracks,
                 score,
                 has_free_upload_slot: peer.is_some_and(|resp| resp.has_free_upload_slot),
                 queue_length: peer.map(|resp| resp.queue_length).unwrap_or(0),
@@ -630,11 +760,54 @@ pub(crate) fn rank_album_folders(
 
     candidates.sort_by_key(|candidate| {
         (
+            std::cmp::Reverse(candidate.pairable_tracks),
             std::cmp::Reverse(candidate.matched_tracks),
             std::cmp::Reverse(candidate.score),
         )
     });
     candidates.truncate(50);
+
+    if let Some(best) = candidates.first()
+        && (best.matched_tracks as usize) < tracks.len()
+    {
+        // List strictly-unmatched titles (same logic as `matched_tracks`); the
+        // number fallback may still pair some of these at download time.
+        let bundle: Vec<AlbumBundleFile> = best
+            .files
+            .iter()
+            .map(|file| AlbumBundleFile {
+                username: best.username.clone(),
+                filename: file.filename.clone(),
+                size: file.size,
+                extension: file.extension.clone().unwrap_or_default(),
+                track_number: parse_track_number(&file.filename),
+                length: file.length_secs,
+                bit_rate: file.bit_rate,
+            })
+            .collect();
+        let unmatched: Vec<&str> = tracks
+            .iter()
+            .filter(|ctx| choose_track_from_bundle(&bundle, ctx, quality).is_none())
+            .map(|ctx| ctx.track_title.as_str())
+            .take(8)
+            .collect();
+        let sample_files: Vec<&str> = best
+            .files
+            .iter()
+            .take(3)
+            .map(|file| file.filename.as_str())
+            .collect();
+        tracing::debug!(
+            folder = best.folder,
+            matched = best.matched_tracks,
+            pairable = best.pairable_tracks,
+            total = tracks.len(),
+            ?unmatched,
+            ?sample_files,
+            "best album folder has unpaired tracks"
+        );
+    }
+
     candidates
 }
 

--- a/crates/yoink-server/src/providers/soulseek/mod.rs
+++ b/crates/yoink-server/src/providers/soulseek/mod.rs
@@ -35,7 +35,10 @@ use self::{
     },
     models::*,
     transfer::{is_complete_success, is_failure},
-    util::{dedup_queries, normalize, percent_encode_path, sanitize_relative_path},
+    util::{
+        dedup_queries, normalize, normalized_parent_dir, percent_encode_path,
+        sanitize_relative_path,
+    },
 };
 use super::{DownloadTrackContext, PlaybackInfo, ProviderError, SearchTrackResolver};
 
@@ -102,9 +105,15 @@ impl SearchTrackResolver for SoulSeekSource {
     ) -> Result<PlaybackInfo, ProviderError> {
         // Try album-bundle search first, then fall back to per-track search.
         // Each phase yields ranked candidates; failed or unverifiable
-        // downloads fall through to the next candidate.
-        let bundle_candidates = self.find_album_bundle_candidates(ctx, quality).await?;
-        let (path, mut last_error) = self.try_candidates(bundle_candidates, ctx).await;
+        // downloads fall through to the next candidate. An album-search
+        // failure must not disable the per-track fallback.
+        let (path, mut last_error) = match self.find_album_bundle_candidates(ctx, quality).await {
+            Ok(bundle_candidates) => self.try_candidates(bundle_candidates, ctx).await,
+            Err(error) => {
+                warn!(error = %error, "SoulSeek album bundle search failed; trying per-track search");
+                (None, Some(error))
+            }
+        };
         if let Some(path) = path {
             return Ok(PlaybackInfo::LocalFile(path));
         }
@@ -137,13 +146,20 @@ impl SearchTrackResolver for SoulSeekSource {
         quality: &Quality,
     ) -> Result<Vec<ManualSearchCandidate>, ProviderError> {
         // Merge album-level and track-level search results so the user sees
-        // both loose files and complete album folders.
-        let mut responses = self.search_album_queries(ctx, quality).await?;
+        // both loose files and complete album folders. Either search may
+        // fail on its own; error out only when neither produced anything.
+        let (mut responses, album_error) = match self.search_album_queries(ctx, quality).await {
+            Ok(responses) => (responses, None),
+            Err(error) => {
+                warn!(error = %error, "manual album search failed; using track results only");
+                (Vec::new(), Some(error))
+            }
+        };
         match self.search_track_queries(ctx).await {
             Ok(track_responses) => responses.extend(track_responses),
             Err(error) => {
                 if responses.is_empty() {
-                    return Err(error);
+                    return Err(album_error.unwrap_or(error));
                 }
                 warn!(error = %error, "manual track search failed; using album results only");
             }
@@ -178,6 +194,24 @@ impl SearchTrackResolver for SoulSeekSource {
         ctx: &DownloadTrackContext,
         quality: &Quality,
     ) -> Result<PlaybackInfo, ProviderError> {
+        // The file listing is round-tripped through the client, so make sure
+        // every entry actually lives in the folder the user picked before
+        // trusting it.
+        if let Some(stray) = selection
+            .files
+            .iter()
+            .find(|file| normalized_parent_dir(&file.filename) != selection.folder)
+        {
+            return InvalidSelectionSnafu {
+                provider: Provider::Soulseek,
+                reason: format!(
+                    "file '{}' is not in the chosen folder '{}'",
+                    stray.filename, selection.folder
+                ),
+            }
+            .fail();
+        }
+
         let chosen = choose_manual_album_file(&selection.files, &selection.username, ctx, quality)
             .context(NotFoundSnafu {
                 provider: Provider::Soulseek,
@@ -1363,6 +1397,108 @@ mod tests {
         let mut extended = search_file("Noisia/Split The Atom/01 - Machine Gun.flac", 60_000_000);
         extended.length = Some(420);
         let responses = vec![search_response("peer", vec![extended])];
+
+        assert!(rank_candidates(&responses, &ctx, &Quality::Lossless).is_empty());
+    }
+
+    #[test]
+    fn single_track_selection_matches_when_catalog_title_has_mix_credit() {
+        // MusicBrainz title carries a mix credit the file drops.
+        let ctx = DownloadTrackContext {
+            track_title: "Thinking of You (David Riva mix)".to_string(),
+            duration_secs: None,
+            ..machine_gun_context()
+        };
+        let file = search_file(
+            "Noisia/Split The Atom/03 - Thinking Of You.flac",
+            30_000_000,
+        );
+        let responses = vec![search_response("peer", vec![file])];
+
+        assert!(!rank_candidates(&responses, &ctx, &Quality::Lossless).is_empty());
+    }
+
+    #[test]
+    fn single_track_selection_core_title_still_rejects_wrong_versions() {
+        // Core-title matching must not open the door to instrumentals.
+        let ctx = DownloadTrackContext {
+            track_title: "Thinking of You (David Riva mix)".to_string(),
+            duration_secs: None,
+            ..machine_gun_context()
+        };
+        let file = search_file(
+            "Noisia/Split The Atom/03 - Thinking Of You (Instrumental).flac",
+            30_000_000,
+        );
+        let responses = vec![search_response("peer", vec![file])];
+
+        assert!(rank_candidates(&responses, &ctx, &Quality::Lossless).is_empty());
+    }
+
+    fn unity_mixers_context(title: &str, number: u32) -> DownloadTrackContext {
+        DownloadTrackContext {
+            artist_name: "The Unity Mixers".to_string(),
+            album_title: "Dance Computer 95 2".to_string(),
+            track_title: title.to_string(),
+            track_number: Some(number),
+            album_track_count: Some(36),
+            duration_secs: None,
+        }
+    }
+
+    #[test]
+    fn single_track_selection_fuzzy_matches_word_variations() {
+        // Catalog says "Thinking of You", the file says "Think Of You", and
+        // the file carries an original-artist credit — both must be bridged.
+        let ctx = unity_mixers_context("Thinking of You (David Riva mix)", 3);
+        let file = search_file(
+            "The Unity Mixers/Dance Computer 95 Vol. 2/03 Whigfield - Think Of You (David Riva Mix).flac",
+            30_000_000,
+        );
+        let responses = vec![search_response("peer", vec![file])];
+
+        assert!(!rank_candidates(&responses, &ctx, &Quality::Lossless).is_empty());
+    }
+
+    #[test]
+    fn single_track_selection_trusts_artist_credit_prefix_in_album_folder() {
+        // "NN Original Artist - Title" naming, no duration metadata: the
+        // album folder context vouches for it.
+        let ctx = unity_mixers_context("You Took My Lovin'", 8);
+        let file = search_file(
+            "The Unity Mixers/Dance Computer 95 Vol. 2/08 Real McCoy - You Took My Lovin'.flac",
+            30_000_000,
+        );
+        let responses = vec![search_response("peer", vec![file])];
+
+        assert!(!rank_candidates(&responses, &ctx, &Quality::Lossless).is_empty());
+    }
+
+    #[test]
+    fn single_track_selection_trailing_segment_rejects_extended_titles() {
+        // Album context is not enough when the trailing segment is a
+        // different, longer title.
+        let ctx = machine_gun_context(); // "Machine Gun", 245s
+        let mut wrong = search_file(
+            "Noisia/Split The Atom/01 Klute - Machine Gun Etiquette.flac",
+            30_000_000,
+        );
+        wrong.length = None;
+        let responses = vec![search_response("peer", vec![wrong])];
+
+        assert!(rank_candidates(&responses, &ctx, &Quality::Lossless).is_empty());
+    }
+
+    #[test]
+    fn single_track_selection_fuzzy_does_not_bridge_prefix_extensions() {
+        // "Fire" must not fuzzy-match "Firewater".
+        let ctx = DownloadTrackContext {
+            track_title: "Fire".to_string(),
+            duration_secs: None,
+            ..machine_gun_context()
+        };
+        let file = search_file("Noisia/Split The Atom/01 - Firewater.flac", 30_000_000);
+        let responses = vec![search_response("peer", vec![file])];
 
         assert!(rank_candidates(&responses, &ctx, &Quality::Lossless).is_empty());
     }

--- a/crates/yoink-server/src/providers/soulseek/mod.rs
+++ b/crates/yoink-server/src/providers/soulseek/mod.rs
@@ -29,12 +29,18 @@ use crate::{
 };
 
 use self::{
-    matching::{pick_best_candidate, pick_from_album_bundle},
+    matching::{
+        choose_manual_album_file, rank_album_bundles, rank_album_folders, rank_all_files,
+        rank_candidates,
+    },
     models::*,
     transfer::{is_complete_success, is_failure},
     util::{dedup_queries, normalize, percent_encode_path, sanitize_relative_path},
 };
 use super::{DownloadTrackContext, PlaybackInfo, ProviderError, SearchTrackResolver};
+
+/// How many ranked candidates to attempt before giving up on a track.
+const MAX_DOWNLOAD_ATTEMPTS: usize = 3;
 
 // ── Source ───────────────────────────────────────────────────────────
 
@@ -47,6 +53,8 @@ pub(crate) struct SoulSeekSource {
     token: RwLock<Option<String>>,
     /// slskd allows only one concurrent `POST /searches` operation.
     search_request_gate: Semaphore,
+    /// slskd also allows only one concurrent download-enqueue operation.
+    transfer_request_gate: Semaphore,
 }
 
 impl SoulSeekSource {
@@ -74,6 +82,7 @@ impl SoulSeekSource {
             downloads_dir: PathBuf::from(downloads_dir.trim()),
             token: RwLock::new(None),
             search_request_gate: Semaphore::new(1),
+            transfer_request_gate: Semaphore::new(1),
         }
     }
 }
@@ -92,54 +101,125 @@ impl SearchTrackResolver for SoulSeekSource {
         quality: &Quality,
     ) -> Result<PlaybackInfo, ProviderError> {
         // Try album-bundle search first, then fall back to per-track search.
-        let candidate = match self.find_album_bundle_candidate(ctx, quality).await? {
-            Some(c) => c,
-            None => self.find_single_track_candidate(ctx, quality).await?,
-        };
+        // Each phase yields ranked candidates; failed or unverifiable
+        // downloads fall through to the next candidate.
+        let bundle_candidates = self.find_album_bundle_candidates(ctx, quality).await?;
+        let (path, mut last_error) = self.try_candidates(bundle_candidates, ctx).await;
+        if let Some(path) = path {
+            return Ok(PlaybackInfo::LocalFile(path));
+        }
 
-        self.enqueue_download(&candidate.username, &candidate.filename, candidate.size)
-            .await?;
-
-        let local_path = match self
-            .wait_for_download(&candidate.username, &candidate.filename, 180)
-            .await
-        {
-            Ok(path) => path,
-            Err(e) => {
-                warn!(
-                    username = candidate.username,
-                    filename = candidate.filename,
-                    error = %e,
-                    "SoulSeek transfer did not complete in time"
-                );
-                return Err(e);
+        match self.find_single_track_candidates(ctx, quality).await {
+            Ok(candidates) => {
+                let (path, error) = self.try_candidates(candidates, ctx).await;
+                if let Some(path) = path {
+                    return Ok(PlaybackInfo::LocalFile(path));
+                }
+                last_error = error.or(last_error);
             }
-        };
+            // A transfer failure from the bundle phase is more informative
+            // than "no single-track candidate found".
+            Err(error) => last_error = last_error.or(Some(error)),
+        }
 
-        Ok(PlaybackInfo::LocalFile(local_path))
+        Err(last_error.unwrap_or_else(|| {
+            NotFoundSnafu {
+                provider: Provider::Soulseek,
+                resource: format!("suitable candidate for '{}'", ctx.track_title),
+            }
+            .build()
+        }))
+    }
+
+    async fn manual_search(
+        &self,
+        ctx: &DownloadTrackContext,
+        quality: &Quality,
+    ) -> Result<Vec<ManualSearchCandidate>, ProviderError> {
+        // Merge album-level and track-level search results so the user sees
+        // both loose files and complete album folders.
+        let mut responses = self.search_album_queries(ctx, quality).await?;
+        match self.search_track_queries(ctx).await {
+            Ok(track_responses) => responses.extend(track_responses),
+            Err(error) => {
+                if responses.is_empty() {
+                    return Err(error);
+                }
+                warn!(error = %error, "manual track search failed; using album results only");
+            }
+        }
+
+        Ok(rank_all_files(&responses, ctx, quality))
+    }
+
+    async fn fetch_file(
+        &self,
+        selection: &ManualDownloadSelection,
+    ) -> Result<PlaybackInfo, ProviderError> {
+        self.fetch_chosen_file(&selection.username, &selection.filename, selection.size)
+            .await
+    }
+
+    async fn manual_album_search(
+        &self,
+        tracks: &[DownloadTrackContext],
+        quality: &Quality,
+    ) -> Result<Vec<ManualAlbumCandidate>, ProviderError> {
+        let Some(first) = tracks.first() else {
+            return Ok(Vec::new());
+        };
+        let responses = self.search_album_queries(first, quality).await?;
+        Ok(rank_album_folders(&responses, tracks, quality))
+    }
+
+    async fn fetch_album_file(
+        &self,
+        selection: &ManualAlbumSelection,
+        ctx: &DownloadTrackContext,
+        quality: &Quality,
+    ) -> Result<PlaybackInfo, ProviderError> {
+        let chosen = choose_manual_album_file(&selection.files, &selection.username, ctx, quality)
+            .context(NotFoundSnafu {
+                provider: Provider::Soulseek,
+                resource: format!(
+                    "file matching '{}' in chosen folder {}",
+                    ctx.track_title, selection.folder
+                ),
+            })?;
+
+        self.fetch_chosen_file(&selection.username, &chosen.filename, chosen.size)
+            .await
     }
 }
 
 // ── High-level search strategies ────────────────────────────────────
 
 impl SoulSeekSource {
-    async fn find_album_bundle_candidate(
+    async fn find_album_bundle_candidates(
         &self,
         ctx: &DownloadTrackContext,
         quality: &Quality,
-    ) -> Result<Option<matching::Candidate>, ProviderError> {
+    ) -> Result<Vec<matching::Candidate>, ProviderError> {
         let responses = self.search_album_queries(ctx, quality).await?;
         if responses.is_empty() {
-            return Ok(None);
+            return Ok(Vec::new());
         }
-        Ok(pick_from_album_bundle(&responses, ctx, quality))
+        let candidates = rank_album_bundles(&responses, ctx, quality);
+        debug!(
+            track = ctx.track_title,
+            responses = responses.len(),
+            files = responses.iter().map(|r| r.files.len()).sum::<usize>(),
+            candidates = candidates.len(),
+            "SoulSeek album bundle ranking"
+        );
+        Ok(candidates)
     }
 
-    async fn find_single_track_candidate(
+    async fn find_single_track_candidates(
         &self,
         ctx: &DownloadTrackContext,
         quality: &Quality,
-    ) -> Result<matching::Candidate, ProviderError> {
+    ) -> Result<Vec<matching::Candidate>, ProviderError> {
         let responses = self.search_track_queries(ctx).await?;
 
         ensure!(
@@ -150,10 +230,91 @@ impl SoulSeekSource {
             }
         );
 
-        pick_best_candidate(&responses, ctx, quality).context(NotFoundSnafu {
-            provider: Provider::Soulseek,
-            resource: format!("suitable candidate for '{}'", ctx.track_title),
-        })
+        let candidates = rank_candidates(&responses, ctx, quality);
+        debug!(
+            track = ctx.track_title,
+            responses = responses.len(),
+            files = responses.iter().map(|r| r.files.len()).sum::<usize>(),
+            candidates = candidates.len(),
+            "SoulSeek single-track ranking"
+        );
+        ensure!(
+            !candidates.is_empty(),
+            NotFoundSnafu {
+                provider: Provider::Soulseek,
+                resource: format!("suitable candidate for '{}'", ctx.track_title),
+            }
+        );
+        Ok(candidates)
+    }
+
+    /// Attempt up to [`MAX_DOWNLOAD_ATTEMPTS`] candidates in ranked order.
+    /// Returns the first verified local file, plus the last error when every
+    /// attempt failed.
+    async fn try_candidates(
+        &self,
+        candidates: Vec<matching::Candidate>,
+        ctx: &DownloadTrackContext,
+    ) -> (Option<PathBuf>, Option<ProviderError>) {
+        let mut last_error = None;
+
+        for candidate in candidates.into_iter().take(MAX_DOWNLOAD_ATTEMPTS) {
+            match self.download_and_verify(&candidate, ctx).await {
+                Ok(path) => return (Some(path), None),
+                Err(error) => {
+                    warn!(
+                        username = candidate.username,
+                        filename = candidate.filename,
+                        error = %error,
+                        "SoulSeek candidate failed; trying next"
+                    );
+                    last_error = Some(error);
+                }
+            }
+        }
+
+        (None, last_error)
+    }
+
+    /// Download a specific user-chosen file. Only checks the result is
+    /// readable audio — no duration second-guessing, the user picked it
+    /// deliberately.
+    async fn fetch_chosen_file(
+        &self,
+        username: &str,
+        filename: &str,
+        size: i64,
+    ) -> Result<PlaybackInfo, ProviderError> {
+        debug!(username, filename, "SoulSeek manual download enqueueing");
+        self.enqueue_download(username, filename, size).await?;
+        let local_path = self.wait_for_download(username, filename, 300).await?;
+        probe_audio_duration(&local_path).await?;
+        Ok(PlaybackInfo::LocalFile(local_path))
+    }
+
+    async fn download_and_verify(
+        &self,
+        candidate: &matching::Candidate,
+        ctx: &DownloadTrackContext,
+    ) -> Result<PathBuf, ProviderError> {
+        debug!(
+            username = candidate.username,
+            filename = candidate.filename,
+            score = candidate.score,
+            "SoulSeek download enqueueing"
+        );
+        self.enqueue_download(&candidate.username, &candidate.filename, candidate.size)
+            .await?;
+        let local_path = self
+            .wait_for_download(&candidate.username, &candidate.filename, 180)
+            .await?;
+        verify_downloaded_file(&local_path, candidate, ctx).await?;
+        debug!(
+            filename = candidate.filename,
+            path = %local_path.display(),
+            "SoulSeek download verified"
+        );
+        Ok(local_path)
     }
 
     /// Build track-level queries from most precise to broadest and return the
@@ -500,7 +661,46 @@ impl SoulSeekSource {
 // ── Download / transfer ─────────────────────────────────────────────
 
 impl SoulSeekSource {
+    /// Enqueue a download, serialized through the transfer gate and retried
+    /// with backoff: slskd rejects concurrent enqueue operations with 429.
     async fn enqueue_download(
+        &self,
+        username: &str,
+        filename: &str,
+        size: i64,
+    ) -> Result<(), ProviderError> {
+        let Ok(_permit) = self.transfer_request_gate.acquire().await else {
+            return UnavailableSnafu {
+                provider: Provider::Soulseek,
+                reason: "transfer gate closed",
+            }
+            .fail();
+        };
+
+        let mut delay_secs = 1u64;
+        for attempt in 1..=6 {
+            match self.enqueue_download_once(username, filename, size).await {
+                Ok(()) => return Ok(()),
+                Err(err) if is_rate_limited(&err) && attempt < 6 => {
+                    warn!(
+                        username,
+                        filename, attempt, delay_secs, "slskd enqueue rate-limited; retrying"
+                    );
+                    tokio::time::sleep(Duration::from_secs(delay_secs)).await;
+                    delay_secs = (delay_secs * 2).min(8);
+                }
+                Err(err) => return Err(err),
+            }
+        }
+
+        RateLimitedSnafu {
+            provider: Provider::Soulseek,
+            reason: "download enqueue failed after retries",
+        }
+        .fail()
+    }
+
+    async fn enqueue_download_once(
         &self,
         username: &str,
         filename: &str,
@@ -653,6 +853,83 @@ impl SoulSeekSource {
 
 // ── Helpers ─────────────────────────────────────────────────────────
 
+/// Read the real duration of a downloaded file, failing if it is not
+/// parseable audio at all.
+async fn probe_audio_duration(path: &Path) -> Result<Duration, ProviderError> {
+    use lofty::{file::AudioFile, probe::Probe};
+
+    let probe_path = path.to_path_buf();
+    let probed = tokio::task::spawn_blocking(move || {
+        Probe::open(&probe_path)
+            .and_then(|probe| probe.read())
+            .map(|file| file.properties().duration())
+    })
+    .await;
+
+    match probed {
+        Ok(Ok(duration)) => Ok(duration),
+        Ok(Err(error)) => InvalidResponseSnafu {
+            provider: Provider::Soulseek,
+            reason: format!(
+                "downloaded file {} is not readable audio: {error}",
+                path.display()
+            ),
+        }
+        .fail(),
+        Err(error) => InvalidResponseSnafu {
+            provider: Provider::Soulseek,
+            reason: format!("audio probe task failed for {}: {error}", path.display()),
+        }
+        .fail(),
+    }
+}
+
+/// Probe the downloaded file and check it is readable audio with a credible
+/// duration, so a bad grab falls through to the next candidate instead of
+/// landing in the library.
+///
+/// The primary duration reference is what the peer advertised in the search
+/// result — matching already vetted that value, and comparing against it
+/// catches truncated transfers and lying peers. Only when nothing was
+/// advertised do we fall back to the catalog duration, generously: it can be
+/// legitimately far off for the same recording (megamix segment boundaries,
+/// pressing differences).
+async fn verify_downloaded_file(
+    path: &Path,
+    candidate: &matching::Candidate,
+    ctx: &DownloadTrackContext,
+) -> Result<(), ProviderError> {
+    let duration = probe_audio_duration(path).await?;
+
+    let actual = u32::try_from(duration.as_secs()).unwrap_or(u32::MAX);
+    if let Some(reported) = candidate.reported_length {
+        ensure!(
+            actual.abs_diff(reported) <= 10,
+            InvalidResponseSnafu {
+                provider: Provider::Soulseek,
+                reason: format!(
+                    "downloaded file {} lasts {actual}s but the peer advertised {reported}s",
+                    path.display()
+                ),
+            }
+        );
+    } else if let Some(expected) = ctx.duration_secs {
+        let tolerance = 45.max(expected / 3);
+        ensure!(
+            actual.abs_diff(expected) <= tolerance,
+            InvalidResponseSnafu {
+                provider: Provider::Soulseek,
+                reason: format!(
+                    "downloaded file {} lasts {actual}s but roughly {expected}s was expected",
+                    path.display()
+                ),
+            }
+        );
+    }
+
+    Ok(())
+}
+
 fn is_rate_limited(err: &ProviderError) -> bool {
     if matches!(err, ProviderError::RateLimited { .. }) {
         return true;
@@ -726,6 +1003,16 @@ mod tests {
                 .extension()
                 .and_then(|e| e.to_str())
                 .map(|s| s.to_string()),
+        }
+    }
+
+    fn search_response(username: &str, files: Vec<SearchFile>) -> SearchResponse {
+        SearchResponse {
+            username: username.to_string(),
+            files,
+            has_free_upload_slot: false,
+            queue_length: 0,
+            upload_speed: 0,
         }
     }
 
@@ -823,59 +1110,91 @@ mod tests {
     #[test]
     fn album_bundle_selection_requires_complete_track_count() {
         let ctx = test_context("Song Two", 2, 3);
-        let responses = vec![SearchResponse {
-            username: "user1".to_string(),
-            files: vec![
+        let responses = vec![search_response(
+            "user1",
+            vec![
                 search_file("The Artist/The Album/01 - Song One.flac", 100),
                 search_file("The Artist/The Album/02 - Song Two.flac", 100),
             ],
-        }];
+        )];
 
-        let candidate = pick_from_album_bundle(&responses, &ctx, &Quality::Lossless);
-        assert!(candidate.is_none());
+        assert!(rank_album_bundles(&responses, &ctx, &Quality::Lossless).is_empty());
     }
 
     #[test]
     fn album_bundle_selection_picks_requested_track_from_complete_bundle() {
         let ctx = test_context("Song Two", 2, 2);
-        let responses = vec![SearchResponse {
-            username: "user1".to_string(),
-            files: vec![
+        let responses = vec![search_response(
+            "user1",
+            vec![
                 search_file("The Artist/The Album/01 - Song One.flac", 100),
                 search_file("The Artist/The Album/02 - Song Two.flac", 100),
             ],
-        }];
+        )];
 
-        let candidate = pick_from_album_bundle(&responses, &ctx, &Quality::Lossless)
+        let candidates = rank_album_bundles(&responses, &ctx, &Quality::Lossless);
+        let candidate = candidates
+            .first()
             .expect("expected complete album candidate");
         assert_eq!(candidate.username, "user1");
         assert!(candidate.filename.contains("02 - Song Two"));
     }
 
     #[test]
-    fn album_bundle_selection_rejects_track_number_with_wrong_title() {
+    fn album_bundle_selection_falls_back_to_title_when_numbering_differs() {
+        // The DB says track 2, but this pressing has the song at position 1:
+        // the title match must win over the track number.
         let ctx = test_context("Song One", 2, 2);
-        let responses = vec![SearchResponse {
-            username: "user1".to_string(),
-            files: vec![
+        let responses = vec![search_response(
+            "user1",
+            vec![
                 search_file("The Artist/The Album/01 - Song One.flac", 100),
                 search_file("The Artist/The Album/02 - Interlude.flac", 100),
             ],
-        }];
+        )];
 
-        let candidate = pick_from_album_bundle(&responses, &ctx, &Quality::Lossless);
-        assert!(candidate.is_none());
+        let candidates = rank_album_bundles(&responses, &ctx, &Quality::Lossless);
+        let candidate = candidates.first().expect("expected title-matched track");
+        assert!(candidate.filename.contains("01 - Song One"));
+    }
+
+    #[test]
+    fn album_bundle_selection_rejects_bundle_without_any_title_match() {
+        let ctx = test_context("Song Three", 2, 2);
+        let responses = vec![search_response(
+            "user1",
+            vec![
+                search_file("The Artist/The Album/01 - Song One.flac", 100),
+                search_file("The Artist/The Album/02 - Interlude.flac", 100),
+            ],
+        )];
+
+        assert!(rank_album_bundles(&responses, &ctx, &Quality::Lossless).is_empty());
+    }
+
+    #[test]
+    fn album_bundle_selection_rejects_folder_without_artist_or_album_context() {
+        let ctx = test_context("Song Two", 2, 2);
+        let responses = vec![search_response(
+            "user1",
+            vec![
+                search_file("shared/random stuff/01 - Song One.flac", 100),
+                search_file("shared/random stuff/02 - Song Two.flac", 100),
+            ],
+        )];
+
+        assert!(rank_album_bundles(&responses, &ctx, &Quality::Lossless).is_empty());
     }
 
     #[test]
     fn single_track_selection_ignores_non_audio_files() {
         let ctx = test_context("Song One", 1, 1);
-        let responses = vec![SearchResponse {
-            username: "user1".to_string(),
-            files: vec![search_file("The Artist/The Album/Song One.jpg", 100)],
-        }];
+        let responses = vec![search_response(
+            "user1",
+            vec![search_file("The Artist/The Album/Song One.jpg", 100)],
+        )];
 
-        assert!(pick_best_candidate(&responses, &ctx, &Quality::Lossless).is_none());
+        assert!(rank_candidates(&responses, &ctx, &Quality::Lossless).is_empty());
     }
 
     #[test]
@@ -883,61 +1202,174 @@ mod tests {
         let ctx = test_context("Song One", 1, 1);
         let mut file = search_file("The Artist/The Album/Song One.FLAC", 100);
         file.extension = None;
-        let responses = vec![SearchResponse {
-            username: "user1".to_string(),
-            files: vec![file],
-        }];
+        let responses = vec![search_response("user1", vec![file])];
 
-        let candidate = pick_best_candidate(&responses, &ctx, &Quality::Lossless)
-            .expect("expected audio candidate");
+        let candidates = rank_candidates(&responses, &ctx, &Quality::Lossless);
+        let candidate = candidates.first().expect("expected audio candidate");
         assert!(candidate.filename.ends_with("Song One.FLAC"));
     }
 
-    #[test]
-    fn single_track_selection_rejects_title_substring_from_different_song() {
-        let ctx = DownloadTrackContext {
+    fn machine_gun_context() -> DownloadTrackContext {
+        DownloadTrackContext {
             artist_name: "Noisia".to_string(),
             album_title: "Split The Atom".to_string(),
             track_title: "Machine Gun".to_string(),
             track_number: Some(1),
             album_track_count: Some(19),
             duration_secs: Some(245),
-        };
+        }
+    }
+
+    #[test]
+    fn single_track_selection_rejects_title_substring_from_different_song() {
+        let ctx = machine_gun_context();
         let mut wrong = search_file(
             "shared/_Untagged/Klute_Unknown Artist/_Unknown Album/03 - Machine Gun Etiquette.flac",
             50_730_582,
         );
         wrong.length = Some(444);
-        let responses = vec![SearchResponse {
-            username: "peer".to_string(),
-            files: vec![wrong],
-        }];
+        let responses = vec![search_response("peer", vec![wrong])];
 
-        assert!(pick_best_candidate(&responses, &ctx, &Quality::Lossless).is_none());
+        assert!(rank_candidates(&responses, &ctx, &Quality::Lossless).is_empty());
     }
 
     #[test]
     fn single_track_selection_accepts_compatible_title_and_duration() {
-        let ctx = DownloadTrackContext {
-            artist_name: "Noisia".to_string(),
-            album_title: "Split The Atom".to_string(),
-            track_title: "Machine Gun".to_string(),
-            track_number: Some(1),
-            album_track_count: Some(19),
-            duration_secs: Some(245),
-        };
+        let ctx = machine_gun_context();
         let mut correct = search_file(
             "Noisia/Split The Atom/01 - Noisia - Machine Gun (Original Mix).flac",
             30_000_000,
         );
         correct.length = Some(245);
-        let responses = vec![SearchResponse {
-            username: "peer".to_string(),
-            files: vec![correct],
-        }];
+        let responses = vec![search_response("peer", vec![correct])];
 
-        let candidate = pick_best_candidate(&responses, &ctx, &Quality::Lossless)
-            .expect("expected compatible candidate");
+        let candidates = rank_candidates(&responses, &ctx, &Quality::Lossless);
+        let candidate = candidates.first().expect("expected compatible candidate");
         assert!(candidate.filename.contains("Machine Gun (Original Mix)"));
+    }
+
+    #[test]
+    fn single_track_selection_rejects_wrong_version_markers() {
+        let ctx = machine_gun_context();
+        let mut instrumental = search_file(
+            "Noisia/Split The Atom/01 - Noisia - Machine Gun (Instrumental).flac",
+            30_000_000,
+        );
+        instrumental.length = Some(245);
+        let responses = vec![search_response("peer", vec![instrumental])];
+
+        assert!(rank_candidates(&responses, &ctx, &Quality::Lossless).is_empty());
+    }
+
+    #[test]
+    fn single_track_selection_allows_version_marker_requested_in_title() {
+        let ctx = DownloadTrackContext {
+            track_title: "Machine Gun (16 Bit Remix)".to_string(),
+            ..machine_gun_context()
+        };
+        let mut remix = search_file(
+            "Noisia/Split The Atom/19 - Machine Gun (16 Bit Remix).flac",
+            30_000_000,
+        );
+        remix.length = Some(245);
+        let responses = vec![search_response("peer", vec![remix])];
+
+        assert!(!rank_candidates(&responses, &ctx, &Quality::Lossless).is_empty());
+    }
+
+    #[test]
+    fn single_track_selection_forgives_one_missing_token_with_context() {
+        // Title "Machine Gun Part 2" vs filename "... Machine Gun Pt 2 ...":
+        // one token differs, but artist context and duration line up.
+        let ctx = DownloadTrackContext {
+            track_title: "Machine Gun Part 2".to_string(),
+            ..machine_gun_context()
+        };
+        let mut close = search_file(
+            "Noisia/Split The Atom/02 - Noisia - Machine Gun Pt 2.flac",
+            30_000_000,
+        );
+        close.length = Some(245);
+        let responses = vec![search_response("peer", vec![close])];
+
+        assert!(!rank_candidates(&responses, &ctx, &Quality::Lossless).is_empty());
+    }
+
+    #[test]
+    fn single_track_selection_ranks_multiple_candidates_best_first() {
+        let ctx = machine_gun_context();
+        let mut flac = search_file("Noisia/Split The Atom/01 - Machine Gun.flac", 30_000_000);
+        flac.length = Some(245);
+        let mut mp3 = search_file("Noisia/Split The Atom/01 - Machine Gun.mp3", 8_000_000);
+        mp3.length = Some(245);
+        let responses = vec![search_response("peer", vec![mp3, flac])];
+
+        let candidates = rank_candidates(&responses, &ctx, &Quality::Lossless);
+        assert_eq!(candidates.len(), 2);
+        assert!(candidates[0].filename.ends_with(".flac"));
+        assert!(candidates[0].score > candidates[1].score);
+    }
+
+    #[test]
+    fn single_track_selection_matches_joined_and_split_words() {
+        // "Sky High" requested, file says "Skyhigh" — and vice versa.
+        let ctx = DownloadTrackContext {
+            track_title: "Sky High".to_string(),
+            ..machine_gun_context()
+        };
+        let mut joined = search_file("Noisia/Split The Atom/02 - Skyhigh.flac", 30_000_000);
+        joined.length = Some(245);
+        let responses = vec![search_response("peer", vec![joined])];
+        assert!(!rank_candidates(&responses, &ctx, &Quality::Lossless).is_empty());
+
+        let ctx = DownloadTrackContext {
+            track_title: "Skyhigh".to_string(),
+            ..machine_gun_context()
+        };
+        let mut split = search_file("Noisia/Split The Atom/02 - Sky High.flac", 30_000_000);
+        split.length = Some(245);
+        let responses = vec![search_response("peer", vec![split])];
+        assert!(!rank_candidates(&responses, &ctx, &Quality::Lossless).is_empty());
+    }
+
+    #[test]
+    fn single_track_selection_compact_match_rejects_unrelated_leftover() {
+        // "Machine Gun" is a compact substring of "Machine Gun Etiquette",
+        // but the leftover is another song's title, not noise.
+        let ctx = machine_gun_context();
+        let mut wrong = search_file("random/03 - MachineGun Etiquette.flac", 30_000_000);
+        wrong.length = None;
+        let responses = vec![search_response("peer", vec![wrong])];
+
+        assert!(rank_candidates(&responses, &ctx, &Quality::Lossless).is_empty());
+    }
+
+    #[test]
+    fn single_track_selection_tolerates_moderate_duration_drift_on_strong_title() {
+        // Megamix segment boundaries and pressing differences shift durations
+        // by tens of seconds; an exact title match must survive that.
+        let ctx = machine_gun_context(); // expects 245s
+        let mut drifted = search_file("Noisia/Split The Atom/01 - Machine Gun.flac", 30_000_000);
+        drifted.length = Some(200);
+        let responses = vec![search_response("peer", vec![drifted])];
+
+        assert!(!rank_candidates(&responses, &ctx, &Quality::Lossless).is_empty());
+    }
+
+    #[test]
+    fn single_track_selection_still_rejects_grossly_wrong_duration() {
+        // A same-named file nearly twice as long is a different version.
+        let ctx = machine_gun_context(); // expects 245s
+        let mut extended = search_file("Noisia/Split The Atom/01 - Machine Gun.flac", 60_000_000);
+        extended.length = Some(420);
+        let responses = vec![search_response("peer", vec![extended])];
+
+        assert!(rank_candidates(&responses, &ctx, &Quality::Lossless).is_empty());
+    }
+
+    #[test]
+    fn normalize_transliterates_accented_characters() {
+        assert_eq!(normalize("Beyoncé"), "beyonce");
+        assert_eq!(normalize("Sigur Rós"), "sigur ros");
     }
 }

--- a/crates/yoink-server/src/providers/soulseek/models.rs
+++ b/crates/yoink-server/src/providers/soulseek/models.rs
@@ -31,6 +31,12 @@ pub(crate) struct SearchStatus {
 pub(crate) struct SearchResponse {
     pub username: String,
     pub files: Vec<SearchFile>,
+    #[serde(default)]
+    pub has_free_upload_slot: bool,
+    #[serde(default)]
+    pub queue_length: u32,
+    #[serde(default)]
+    pub upload_speed: u32,
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/yoink-server/src/routes/album.rs
+++ b/crates/yoink-server/src/routes/album.rs
@@ -98,6 +98,8 @@ pub(super) fn router() -> OpenApiRouter<AppState> {
         .routes(routes!(set_album_quality))
         .routes(routes!(remove_album_files))
         .routes(routes!(retry_download))
+        .routes(routes!(manual_search_album))
+        .routes(routes!(manual_download_album))
         .routes(routes!(list_album_providers))
         .routes(routes!(list_album_tracks))
         .routes(routes!(bulk_toggle_track_monitor))
@@ -450,6 +452,64 @@ async fn retry_download(
         .map_err(app_error_response)?;
 
     Ok(StatusCode::NO_CONTENT)
+}
+
+/// Manual Search
+///
+/// Interactive search: returns candidate album folders peers offer for this
+/// album, best-matched first, so the user can pick one manually. Can take up
+/// to a minute.
+#[utoipa::path(
+    get,
+    path = "/{album_id}/manual-search",
+    tag = TAG,
+    params(
+        ("album_id" = Uuid, Path, description = "Album UUID")
+    ),
+    responses(
+        (status = 200, description = "Candidate album folders, best-matched first", body = Vec<crate::providers::ManualAlbumCandidate>),
+        (status = 404, description = "Album not found"),
+        (status = 503, description = "No search-capable download provider available"),
+    )
+)]
+async fn manual_search_album(
+    State(state): State<AppState>,
+    Path(album_id): Path<Uuid>,
+) -> ApiResult<Vec<crate::providers::ManualAlbumCandidate>> {
+    services::jobs::download::manual_search_album(&state, album_id)
+        .await
+        .map_err(app_error_response)
+        .map(Json)
+}
+
+/// Manual Download
+///
+/// Enqueue a download of a specific user-chosen album folder, bypassing
+/// automatic candidate selection.
+#[utoipa::path(
+    post,
+    path = "/{album_id}/manual-download",
+    tag = TAG,
+    params(
+        ("album_id" = Uuid, Path, description = "Album UUID")
+    ),
+    request_body = crate::providers::ManualAlbumSelection,
+    responses(
+        (status = 202, description = "Manual album download job enqueued"),
+        (status = 404, description = "Album not found"),
+        (status = 500, description = "Failed to enqueue download"),
+    )
+)]
+async fn manual_download_album(
+    State(state): State<AppState>,
+    Path(album_id): Path<Uuid>,
+    Json(selection): Json<crate::providers::ManualAlbumSelection>,
+) -> ApiStatusResult {
+    services::jobs::download::enqueue_manual_album_download_job(&state, album_id, selection)
+        .await
+        .map_err(app_error_response)?;
+
+    Ok(StatusCode::ACCEPTED)
 }
 
 /// List Album Providers

--- a/crates/yoink-server/src/routes/track.rs
+++ b/crates/yoink-server/src/routes/track.rs
@@ -1,16 +1,18 @@
 use axum::{
     Json,
-    extract::{Query, State},
+    extract::{Path, Query, State},
     http::StatusCode,
 };
 use serde::Deserialize;
 use utoipa::ToSchema;
 use utoipa_axum::{router::OpenApiRouter, routes};
+use uuid::Uuid;
 
 use crate::api::{LibraryTrack, SearchTrackResult};
 
 use crate::{
     db::provider::Provider,
+    providers::{ManualDownloadSelection, ManualSearchCandidate},
     services::{self, search::SearchQuery},
     state::AppState,
 };
@@ -37,6 +39,8 @@ pub(super) fn router() -> OpenApiRouter<AppState> {
         .routes(routes!(search_tracks))
         .routes(routes!(list_tracks))
         .routes(routes!(create_track))
+        .routes(routes!(manual_search_track))
+        .routes(routes!(manual_download_track))
 }
 
 #[utoipa::path(
@@ -75,6 +79,60 @@ async fn list_tracks(State(state): State<AppState>) -> ApiResult<Vec<LibraryTrac
         .await
         .map_err(app_error_response)
         .map(Json)
+}
+
+#[utoipa::path(
+    get,
+    path = "/{track_id}/manual-search",
+    tag = TAG,
+    params(("track_id" = Uuid, Path, description = "Library track id")),
+    responses(
+        (status = 200, description = "All candidate files found for the track, best-scored first", body = Vec<ManualSearchCandidate>),
+        (status = 404, description = "Track not found"),
+        (status = 503, description = "No search-capable download provider available"),
+    )
+)]
+/// Manual Search
+///
+/// Interactive search: returns every candidate file the download provider
+/// surfaces for this track, including ones the automatic matcher would
+/// reject, so the user can pick one manually. Can take up to a minute.
+async fn manual_search_track(
+    State(state): State<AppState>,
+    Path(track_id): Path<Uuid>,
+) -> ApiResult<Vec<ManualSearchCandidate>> {
+    services::jobs::download::manual_search_track(&state, track_id)
+        .await
+        .map_err(app_error_response)
+        .map(Json)
+}
+
+#[utoipa::path(
+    post,
+    path = "/{track_id}/manual-download",
+    tag = TAG,
+    params(("track_id" = Uuid, Path, description = "Library track id")),
+    request_body = ManualDownloadSelection,
+    responses(
+        (status = 202, description = "Manual download job enqueued"),
+        (status = 404, description = "Track not found"),
+        (status = 500, description = "Failed to enqueue download"),
+    )
+)]
+/// Manual Download
+///
+/// Enqueue a download of a specific user-chosen file for this track,
+/// bypassing automatic candidate selection.
+async fn manual_download_track(
+    State(state): State<AppState>,
+    Path(track_id): Path<Uuid>,
+    Json(selection): Json<ManualDownloadSelection>,
+) -> ApiStatusResult {
+    services::jobs::download::enqueue_manual_download_job(&state, track_id, selection)
+        .await
+        .map_err(app_error_response)?;
+
+    Ok(StatusCode::ACCEPTED)
 }
 
 #[utoipa::path(

--- a/crates/yoink-server/src/services/album.rs
+++ b/crates/yoink-server/src/services/album.rs
@@ -516,6 +516,7 @@ mod tests {
                 payload: DownloadAlbumJobPayload {
                     album_id: album.id,
                     provider: db::provider::Provider::Tidal,
+                    manual: None,
                 },
             },
         )
@@ -587,6 +588,7 @@ mod tests {
                 payload: DownloadAlbumJobPayload {
                     album_id: album.id,
                     provider: db::provider::Provider::Tidal,
+                    manual: None,
                 },
             },
         )
@@ -667,6 +669,7 @@ mod tests {
                 payload: DownloadAlbumJobPayload {
                     album_id: album.id,
                     provider: db::provider::Provider::Tidal,
+                    manual: None,
                 },
             },
         )

--- a/crates/yoink-server/src/services/jobs/download.rs
+++ b/crates/yoink-server/src/services/jobs/download.rs
@@ -45,12 +45,18 @@ use uuid::Uuid;
 pub(crate) struct DownloadAlbumJobPayload {
     pub album_id: uuid::Uuid,
     pub provider: Provider,
+    /// User-chosen album folder that bypasses automatic candidate selection.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub manual: Option<crate::providers::ManualAlbumSelection>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
 pub(crate) struct DownloadTrackJobPayload {
     pub track_id: uuid::Uuid,
     pub provider: Provider,
+    /// User-chosen file that bypasses automatic candidate selection.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub manual: Option<crate::providers::ManualDownloadSelection>,
 }
 
 fn download_jobs() -> [JobKind; 2] {
@@ -121,7 +127,11 @@ pub(crate) async fn enqueue_download_album_job(
         .copied()
         .ok_or(AppError::download("provider", "no providers available"))?;
 
-    let payload = DownloadAlbumJobPayload { album_id, provider };
+    let payload = DownloadAlbumJobPayload {
+        album_id,
+        provider,
+        manual: None,
+    };
     let job = Job::DownloadAlbum { payload };
     enqueue_job(state, job).await
 }
@@ -156,7 +166,11 @@ pub(crate) async fn enqueue_download_track_job(
         .copied()
         .ok_or(AppError::download("provider", "no providers available"))?;
 
-    let payload = DownloadTrackJobPayload { track_id, provider };
+    let payload = DownloadTrackJobPayload {
+        track_id,
+        provider,
+        manual: None,
+    };
     let job = Job::DownloadTrack { payload };
     enqueue_job(state, job).await
 }
@@ -183,6 +197,173 @@ pub(crate) async fn retry_album_download(state: &AppState, album_id: Uuid) -> Ap
     // enqueue a new DL job for the album
     enqueue_download_album_job(state, album_id).await?;
     Ok(())
+}
+
+/// Load a track's album context and build its search plan, plus the
+/// preferred search-capable download source.
+async fn search_source_and_plan(
+    state: &AppState,
+    track_id: Uuid,
+) -> AppResult<(Provider, Arc<dyn SearchTrackResolver>, SearchTrackPlan)> {
+    let Some(track) = track::Entity::find_by_id(track_id).one(&state.db).await? else {
+        return Err(AppError::not_found("track", Some(track_id.to_string())));
+    };
+
+    let Some(album) = album::Entity::load()
+        .filter_by_id(track.album_id)
+        .with(album_provider_link::Entity)
+        .with(track::Entity)
+        .with((track::Entity, track_provider_link::Entity))
+        .with((track::Entity, track_artist::Entity))
+        .with((track::Entity, artist::Entity))
+        .one(&state.db)
+        .await?
+    else {
+        return Err(AppError::not_found(
+            "album",
+            Some(track.album_id.to_string()),
+        ));
+    };
+
+    let target_track = album
+        .tracks
+        .iter()
+        .find(|track| track.id == track_id)
+        .cloned()
+        .ok_or_else(|| AppError::not_found("track", Some(track_id.to_string())))?;
+
+    let (provider, source) = state
+        .registry
+        .download_sources()
+        .iter()
+        .filter_map(|source| match source {
+            DownloadSource::Search(resolver) => Some((source.id(), Arc::clone(resolver))),
+            DownloadSource::Linked(_) => None,
+        })
+        .max_by_key(|(provider, _)| provider_priority(*provider))
+        .ok_or_else(|| {
+            AppError::download("provider", "no search-capable download provider available")
+        })?;
+
+    let quality = target_track
+        .quality_override
+        .or(album.requested_quality)
+        .unwrap_or(state.default_quality);
+
+    let album_artist = album
+        .fetch_primary_artist(&state.db)
+        .await?
+        .map(|a| a.name)
+        .unwrap_or("Unknown".to_string());
+
+    let plan = plan_track_by_metadata(&album, &target_track, quality, &album_artist);
+    Ok((provider, source, plan))
+}
+
+/// Run an interactive (manual) search for a track and return every candidate
+/// the provider surfaces, scored but unfiltered.
+pub(crate) async fn manual_search_track(
+    state: &AppState,
+    track_id: Uuid,
+) -> AppResult<Vec<crate::providers::ManualSearchCandidate>> {
+    let (_, source, plan) = search_source_and_plan(state, track_id).await?;
+    Ok(source.manual_search(&plan.metadata, &plan.quality).await?)
+}
+
+/// Build search plans for every track of an album, plus the preferred
+/// search-capable download source.
+async fn album_search_source_and_plans(
+    state: &AppState,
+    album_id: Uuid,
+) -> AppResult<(
+    Provider,
+    Arc<dyn SearchTrackResolver>,
+    VecDeque<SearchTrackPlan>,
+)> {
+    let Some(album) = album::Entity::load()
+        .filter_by_id(album_id)
+        .with(album_provider_link::Entity)
+        .with(track::Entity)
+        .with((track::Entity, track_provider_link::Entity))
+        .with((track::Entity, track_artist::Entity))
+        .with((track::Entity, artist::Entity))
+        .one(&state.db)
+        .await?
+    else {
+        return Err(AppError::not_found("album", Some(album_id.to_string())));
+    };
+
+    let (provider, source) = state
+        .registry
+        .download_sources()
+        .iter()
+        .filter_map(|source| match source {
+            DownloadSource::Search(resolver) => Some((source.id(), Arc::clone(resolver))),
+            DownloadSource::Linked(_) => None,
+        })
+        .max_by_key(|(provider, _)| provider_priority(*provider))
+        .ok_or_else(|| {
+            AppError::download("provider", "no search-capable download provider available")
+        })?;
+
+    let quality = album.requested_quality.unwrap_or(state.default_quality);
+    let album_artist = album
+        .fetch_primary_artist(&state.db)
+        .await?
+        .map(|a| a.name)
+        .unwrap_or("Unknown".to_string());
+
+    let plans = plan_tracks_by_metadata(&album, quality, &album_artist);
+    Ok((provider, source, plans))
+}
+
+/// Run an interactive (manual) search for an album and return candidate
+/// folders, best-matched first.
+pub(crate) async fn manual_search_album(
+    state: &AppState,
+    album_id: Uuid,
+) -> AppResult<Vec<crate::providers::ManualAlbumCandidate>> {
+    let (_, source, plans) = album_search_source_and_plans(state, album_id).await?;
+    let quality = plans
+        .front()
+        .map(|plan| plan.quality)
+        .unwrap_or(state.default_quality);
+    let tracks: Vec<DownloadTrackContext> = plans.into_iter().map(|plan| plan.metadata).collect();
+    Ok(source.manual_album_search(&tracks, &quality).await?)
+}
+
+/// Enqueue an album download job for a specific user-chosen folder.
+pub(crate) async fn enqueue_manual_album_download_job(
+    state: &AppState,
+    album_id: Uuid,
+    selection: crate::providers::ManualAlbumSelection,
+) -> AppResult<job::Model> {
+    // Validates the album exists and a search source is configured.
+    let (provider, _, _) = album_search_source_and_plans(state, album_id).await?;
+
+    let payload = DownloadAlbumJobPayload {
+        album_id,
+        provider,
+        manual: Some(selection),
+    };
+    enqueue_job(state, Job::DownloadAlbum { payload }).await
+}
+
+/// Enqueue a download job for a specific user-chosen file.
+pub(crate) async fn enqueue_manual_download_job(
+    state: &AppState,
+    track_id: Uuid,
+    selection: crate::providers::ManualDownloadSelection,
+) -> AppResult<job::Model> {
+    // Validates the track exists and a search source is configured.
+    let (provider, _, _) = search_source_and_plan(state, track_id).await?;
+
+    let payload = DownloadTrackJobPayload {
+        track_id,
+        provider,
+        manual: Some(selection),
+    };
+    enqueue_job(state, Job::DownloadTrack { payload }).await
 }
 
 async fn process_album_download_job(state: AppState, job: job::ModelEx) -> AppResult<job::ModelEx> {
@@ -258,9 +439,11 @@ async fn process_album_download_job(state: AppState, job: job::ModelEx) -> AppRe
 
     let temp_dir = tempfile::tempdir()?;
 
+    let planned_count;
     let mut join_set = match dl_provider {
         DownloadSource::Linked(source) => {
             let planned_tracks = plan_tracks_by_id(payload, &album, quality)?;
+            planned_count = planned_tracks.len();
             enqueue_linked_tracks(
                 state.clone(),
                 source,
@@ -271,18 +454,35 @@ async fn process_album_download_job(state: AppState, job: job::ModelEx) -> AppRe
         }
         DownloadSource::Search(source) => {
             let planned_tracks = plan_tracks_by_metadata(&album, quality, &album_artist);
-            enqueue_search_tracks(
-                state.clone(),
-                source,
-                temp_dir.path().to_path_buf(),
-                planned_tracks,
-            )
-            .await?
+            planned_count = planned_tracks.len();
+            if let Some(selection) = payload.manual.clone() {
+                enqueue_manual_album_tracks(
+                    state.clone(),
+                    source,
+                    temp_dir.path().to_path_buf(),
+                    planned_tracks,
+                    selection,
+                )
+                .await?
+            } else {
+                enqueue_search_tracks(
+                    state.clone(),
+                    source,
+                    temp_dir.path().to_path_buf(),
+                    planned_tracks,
+                )
+                .await?
+            }
         }
     };
 
-    let total_tracks = album.tracks.len() as f32;
+    let total_tracks = planned_count.max(1) as f32;
     let mut completed_tracks = 0.0_f32;
+
+    // A user-chosen folder may not cover every track: download everything it
+    // can and report the stragglers at the end instead of aborting mid-album.
+    let best_effort = payload.manual.is_some();
+    let mut track_errors: Vec<String> = Vec::new();
 
     // let job = job.into_active_model();
     let mut job = job;
@@ -311,6 +511,10 @@ async fn process_album_download_job(state: AppState, job: job::ModelEx) -> AppRe
         let (track, temp_path, quality) = match dl_result {
             Ok(plan) => plan,
             Err(err) => {
+                if best_effort {
+                    track_errors.push(err.to_string());
+                    continue;
+                }
                 return Err(err);
             }
         };
@@ -349,6 +553,25 @@ async fn process_album_download_job(state: AppState, job: job::ModelEx) -> AppRe
     }
 
     drop(temp_dir);
+
+    if !track_errors.is_empty() {
+        let shown = track_errors.iter().take(3).cloned().collect::<Vec<_>>();
+        let suffix = if track_errors.len() > shown.len() {
+            format!(" (and {} more)", track_errors.len() - shown.len())
+        } else {
+            String::new()
+        };
+        return Err(AppError::download(
+            "album",
+            format!(
+                "{} of {} tracks failed: {}{}",
+                track_errors.len(),
+                planned_count,
+                shown.join("; "),
+                suffix
+            ),
+        ));
+    }
 
     album
         .into_active_model()
@@ -468,13 +691,24 @@ async fn process_track_download_job(state: AppState, job: job::ModelEx) -> AppRe
                 quality,
                 &album_artist,
             )]);
-            enqueue_search_tracks(
-                state.clone(),
-                source,
-                temp_dir.path().to_path_buf(),
-                planned_tracks,
-            )
-            .await?
+            if let Some(selection) = payload.manual.clone() {
+                enqueue_manual_track(
+                    state.clone(),
+                    source,
+                    temp_dir.path().to_path_buf(),
+                    planned_tracks,
+                    selection,
+                )
+                .await?
+            } else {
+                enqueue_search_tracks(
+                    state.clone(),
+                    source,
+                    temp_dir.path().to_path_buf(),
+                    planned_tracks,
+                )
+                .await?
+            }
         }
     };
 
@@ -761,6 +995,57 @@ async fn enqueue_search_tracks(
     .await
 }
 
+/// Download each album track out of a user-chosen album folder instead of
+/// resolving by search.
+async fn enqueue_manual_album_tracks(
+    state: AppState,
+    resolver: Arc<dyn SearchTrackResolver>,
+    temp_dir_path: PathBuf,
+    planned_tracks: VecDeque<SearchTrackPlan>,
+    selection: crate::providers::ManualAlbumSelection,
+) -> Result<JoinSet<AppResult<(track::ModelEx, PathBuf, Quality)>>, AppError> {
+    enqueue_tracks(
+        state,
+        temp_dir_path,
+        planned_tracks,
+        move |plan: SearchTrackPlan| {
+            let resolver = Arc::clone(&resolver);
+            let selection = selection.clone();
+            async move {
+                let playback = resolver
+                    .fetch_album_file(&selection, &plan.metadata, &plan.quality)
+                    .await?;
+                AppResult::Ok((plan.track, playback, plan.quality))
+            }
+        },
+    )
+    .await
+}
+
+/// Download a specific user-chosen file instead of resolving by search.
+async fn enqueue_manual_track(
+    state: AppState,
+    resolver: Arc<dyn SearchTrackResolver>,
+    temp_dir_path: PathBuf,
+    planned_tracks: VecDeque<SearchTrackPlan>,
+    selection: crate::providers::ManualDownloadSelection,
+) -> Result<JoinSet<AppResult<(track::ModelEx, PathBuf, Quality)>>, AppError> {
+    enqueue_tracks(
+        state,
+        temp_dir_path,
+        planned_tracks,
+        move |plan: SearchTrackPlan| {
+            let resolver = Arc::clone(&resolver);
+            let selection = selection.clone();
+            async move {
+                let playback = resolver.fetch_file(&selection).await?;
+                AppResult::Ok((plan.track, playback, plan.quality))
+            }
+        },
+    )
+    .await
+}
+
 async fn enqueue_tracks<P, Resolve, ResolveFuture>(
     state: AppState,
     temp_dir_path: PathBuf,
@@ -855,6 +1140,7 @@ fn plan_tracks_by_id(
     album
         .tracks
         .iter()
+        .filter(|track| track.status != WantedStatus::Acquired)
         .map(|track| plan_track_by_id(payload.provider, track, quality))
         .collect()
 }
@@ -895,6 +1181,8 @@ fn plan_track_by_id(
     })
 }
 
+/// Plan every album track that is not already acquired, so retries after a
+/// partial failure only fetch what is missing.
 fn plan_tracks_by_metadata(
     album: &album::ModelEx,
     quality: Quality,
@@ -903,6 +1191,7 @@ fn plan_tracks_by_metadata(
     album
         .tracks
         .iter()
+        .filter(|track| track.status != WantedStatus::Acquired)
         .map(|track| plan_track_by_metadata(album, track, quality, album_artist))
         .collect()
 }
@@ -935,7 +1224,9 @@ fn plan_track_by_metadata(
         track_title: track.title.clone(),
         track_number: track.track_number.map(|n| n as u32),
         album_track_count: Some(album.tracks.len()),
-        duration_secs: track.duration.map(|d| d as u32),
+        // Providers sometimes store 0 for unknown durations; treat as absent
+        // so matching doesn't hard-reject every candidate.
+        duration_secs: track.duration.filter(|&d| d > 0).map(|d| d as u32),
     };
 
     SearchTrackPlan {
@@ -952,8 +1243,30 @@ fn search_artist_name(track_artist: Option<&str>, album_artist: &str) -> String 
         .to_string()
 }
 
+/// Reset download jobs left `Running` by a previous process. Nothing is
+/// actually running them anymore, so they would otherwise sit orphaned:
+/// invisible to the worker and impossible to cancel.
+async fn requeue_orphaned_jobs(state: &AppState) -> AppResult<()> {
+    let orphaned = job::Entity::find()
+        .filter(job::Column::JobKind.is_in(download_jobs()))
+        .filter(job::Column::Status.eq(JobStatus::Running))
+        .all(&state.db)
+        .await?;
+
+    for job in orphaned {
+        tracing::warn!(job_id = %job.id, "Requeueing download job orphaned by restart");
+        job.into_active_model()
+            .into_ex()
+            .set_status(JobStatus::Queued)
+            .update(&state.db)
+            .await?;
+    }
+    Ok(())
+}
+
 pub(crate) async fn download_worker(state: AppState) -> AppResult<()> {
     tracing::info!("Download worker starting");
+    requeue_orphaned_jobs(&state).await?;
     loop {
         if state.shutdown.is_cancelled() {
             tracing::info!("Download worker shutting down");
@@ -979,21 +1292,52 @@ pub(crate) async fn download_worker(state: AppState) -> AppResult<()> {
             continue;
         };
 
-        let job_result = match &job.data {
-            Job::DownloadAlbum { .. } => {
-                process_album_download_job(state.clone(), job.clone().into_ex()).await
-            }
-            Job::DownloadTrack { .. } => {
-                process_track_download_job(state.clone(), job.clone().into_ex()).await
-            }
+        let cancel_token = state.shutdown.child_token();
+        *state
+            .active_download_job
+            .lock()
+            .expect("active download job lock") = Some((job.id, cancel_token.clone()));
+
+        // Cancelling the token drops the processing future, which aborts any
+        // per-track tasks still in its JoinSet.
+        let job_result = tokio::select! {
+            biased;
+            _ = cancel_token.cancelled() => None,
+            result = async {
+                match &job.data {
+                    Job::DownloadAlbum { .. } => {
+                        process_album_download_job(state.clone(), job.clone().into_ex()).await
+                    }
+                    Job::DownloadTrack { .. } => {
+                        process_track_download_job(state.clone(), job.clone().into_ex()).await
+                    }
+                }
+            } => Some(result),
         };
 
+        *state
+            .active_download_job
+            .lock()
+            .expect("active download job lock") = None;
+
         let job = match job_result {
-            Ok(job) => {
+            None => {
+                if state.shutdown.is_cancelled() {
+                    // Server shutdown, not a user cancel: leave the job
+                    // Running so requeue_orphaned_jobs resumes it next start.
+                    tracing::info!("Download worker shutting down mid-job");
+                    return Ok(());
+                }
+                tracing::info!("Job {} was cancelled", job.id);
+                job.into_active_model()
+                    .into_ex()
+                    .set_status(JobStatus::Cancelled)
+            }
+            Some(Ok(job)) => {
                 tracing::info!("Job {} completed successfully", job.id);
                 job.into_active_model().set_status(JobStatus::Succeeded)
             }
-            Err(err) => {
+            Some(Err(err)) => {
                 tracing::error!(error = %err, "Job {} failed with error", job.id);
                 // TODO increment attempts instead of at the start of the job
                 job.into_active_model()
@@ -1004,6 +1348,7 @@ pub(crate) async fn download_worker(state: AppState) -> AppResult<()> {
         };
 
         job.set_finished_at(Utc::now()).update(&state.db).await?;
+        state.notify_sse();
     }
 }
 

--- a/crates/yoink-server/src/services/jobs/mod.rs
+++ b/crates/yoink-server/src/services/jobs/mod.rs
@@ -114,12 +114,35 @@ pub(crate) async fn cancel_job(state: &AppState, job_id: Uuid) -> AppResult<()> 
         .ok_or(AppError::not_found("job", Some(job_id)))?;
 
     match job.status {
-        JobStatus::Queued => {
+        // Cancelling a Failed job stops the worker from retrying it (see
+        // prepare_track_for_unmonitor).
+        JobStatus::Queued | JobStatus::Failed => {
             job.into_ex()
                 .into_active_model()
                 .set_status(JobStatus::Cancelled)
                 .update(&state.db)
                 .await?;
+        }
+        JobStatus::Running => {
+            let active = state
+                .active_download_job
+                .lock()
+                .expect("active download job lock")
+                .clone();
+            match active {
+                // The worker is processing this job right now: signal it and
+                // let it record the Cancelled status itself.
+                Some((active_id, token)) if active_id == job.id => token.cancel(),
+                // Orphaned `Running` row (e.g. left over from a crash) — no
+                // worker owns it, so it is safe to mark directly.
+                _ => {
+                    job.into_ex()
+                        .into_active_model()
+                        .set_status(JobStatus::Cancelled)
+                        .update(&state.db)
+                        .await?;
+                }
+            }
         }
         _ => {
             return Err(AppError::validation(
@@ -129,6 +152,7 @@ pub(crate) async fn cancel_job(state: &AppState, job_id: Uuid) -> AppResult<()> 
         }
     }
 
+    state.notify_sse();
     Ok(())
 }
 

--- a/crates/yoink-server/src/services/library/merge.rs
+++ b/crates/yoink-server/src/services/library/merge.rs
@@ -720,6 +720,7 @@ mod tests {
                 payload: DownloadAlbumJobPayload {
                     album_id: source_album.id,
                     provider: Provider::Tidal,
+                    manual: None,
                 },
             },
         )

--- a/crates/yoink-server/src/services/track.rs
+++ b/crates/yoink-server/src/services/track.rs
@@ -465,6 +465,7 @@ mod tests {
                 payload: DownloadTrackJobPayload {
                     track_id: track.id,
                     provider: Provider::Tidal,
+                    manual: None,
                 },
             },
         )
@@ -563,6 +564,7 @@ mod tests {
                 payload: DownloadTrackJobPayload {
                     track_id: track.id,
                     provider: Provider::Tidal,
+                    manual: None,
                 },
             },
         )

--- a/crates/yoink-server/src/state.rs
+++ b/crates/yoink-server/src/state.rs
@@ -1,4 +1,7 @@
-use std::{path::PathBuf, sync::Arc};
+use std::{
+    path::PathBuf,
+    sync::{Arc, Mutex},
+};
 
 use migration::MigratorTrait;
 use sea_orm::DatabaseConnection;
@@ -15,6 +18,9 @@ pub(crate) struct AppState {
     pub(crate) db: DatabaseConnection,
     pub(crate) download_notify: Arc<Notify>,
     pub(crate) shutdown: CancellationToken,
+    /// The download job currently being processed, with a token that cancels
+    /// just that job (not the whole worker).
+    pub(crate) active_download_job: Arc<Mutex<Option<(uuid::Uuid, CancellationToken)>>>,
     pub(crate) sse_tx: broadcast::Sender<()>,
     pub(crate) music_root: PathBuf,
     pub(crate) default_quality: Quality,
@@ -54,6 +60,7 @@ impl AppState {
             db: conn,
             download_notify: Arc::new(Notify::new()),
             shutdown: CancellationToken::new(),
+            active_download_job: Arc::new(Mutex::new(None)),
             sse_tx,
             music_root,
             default_quality,

--- a/crates/yoink-server/src/util.rs
+++ b/crates/yoink-server/src/util.rs
@@ -4,13 +4,21 @@
 
 use crate::db::provider::Provider;
 
-/// Normalize text for fuzzy comparison: lowercase (Unicode-aware), strip
-/// non-ASCII-alphanumeric characters, and collapse whitespace.
+/// Normalize text for fuzzy comparison: transliterate to ASCII, lowercase,
+/// strip non-alphanumeric characters, and collapse whitespace.
+///
+/// Transliteration keeps accented and non-Latin titles comparable
+/// ("Beyoncé" → "beyonce") instead of silently dropping characters.
 pub(crate) fn normalize(input: &str) -> String {
-    input
+    deunicode::deunicode_with_tofu(input, " ")
         .chars()
-        .flat_map(|c| c.to_lowercase())
-        .map(|c| if c.is_ascii_alphanumeric() { c } else { ' ' })
+        .map(|c| {
+            if c.is_ascii_alphanumeric() {
+                c.to_ascii_lowercase()
+            } else {
+                ' '
+            }
+        })
         .collect::<String>()
         .split_whitespace()
         .collect::<Vec<_>>()

--- a/frontend/src/lib/api/index.ts
+++ b/frontend/src/lib/api/index.ts
@@ -50,4 +50,6 @@ export {
   useBrowsePath,
   usePreviewExternalImport,
   useConfirmExternalImport,
+  useManualDownload,
+  useManualAlbumDownload,
 } from "./mutations";

--- a/frontend/src/lib/api/mutations.ts
+++ b/frontend/src/lib/api/mutations.ts
@@ -770,3 +770,30 @@ export function useConfirmExternalImport() {
     },
   });
 }
+
+export function useManualDownload() {
+  const qc = useQueryClient();
+  return $api.useMutation("post", "/api/track/{track_id}/manual-download", {
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: ["get", "/api/album/{album_id}"] });
+      void qc.invalidateQueries({ queryKey: queryKeys.jobs.list().queryKey });
+      void qc.invalidateQueries({ queryKey: queryKeys.dashboard().queryKey });
+      void qc.invalidateQueries({ queryKey: queryKeys.wanted().queryKey });
+    },
+  });
+}
+
+export function useManualAlbumDownload() {
+  const qc = useQueryClient();
+  return $api.useMutation("post", "/api/album/{album_id}/manual-download", {
+    onSuccess: (_data, variables) => {
+      void qc.invalidateQueries({
+        queryKey: queryKeys.albums.detail(variables.params.path.album_id).queryKey,
+      });
+      void qc.invalidateQueries({ queryKey: queryKeys.albums.list().queryKey });
+      void qc.invalidateQueries({ queryKey: queryKeys.jobs.list().queryKey });
+      void qc.invalidateQueries({ queryKey: queryKeys.dashboard().queryKey });
+      void qc.invalidateQueries({ queryKey: queryKeys.wanted().queryKey });
+    },
+  });
+}

--- a/frontend/src/lib/api/types.gen.ts
+++ b/frontend/src/lib/api/types.gen.ts
@@ -174,6 +174,49 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/album/{album_id}/manual-download": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Manual Download
+         * @description Enqueue a download of a specific user-chosen album folder, bypassing
+         *     automatic candidate selection.
+         */
+        post: operations["manual_download_album"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/album/{album_id}/manual-search": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Manual Search
+         * @description Interactive search: returns candidate album folders peers offer for this
+         *     album, best-matched first, so the user can pick one manually. Can take up
+         *     to a minute.
+         */
+        get: operations["manual_search_album"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/album/{album_id}/monitor": {
         parameters: {
             query?: never;
@@ -885,6 +928,49 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/track/{track_id}/manual-download": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Manual Download
+         * @description Enqueue a download of a specific user-chosen file for this track,
+         *     bypassing automatic candidate selection.
+         */
+        post: operations["manual_download_track"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/track/{track_id}/manual-search": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Manual Search
+         * @description Interactive search: returns every candidate file the download provider
+         *     surfaces for this track, including ones the automatic matcher would
+         *     reject, so the user can pick one manually. Can take up to a minute.
+         */
+        get: operations["manual_search_track"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/wanted": {
         parameters: {
             query?: never;
@@ -1123,9 +1209,11 @@ export interface components {
         DownloadAlbumJobPayload: {
             /** Format: uuid */
             album_id: string;
+            manual?: null | components["schemas"]["ManualAlbumSelection"];
             provider: components["schemas"]["Provider"];
         };
         DownloadTrackJobPayload: {
+            manual?: null | components["schemas"]["ManualDownloadSelection"];
             provider: components["schemas"]["Provider"];
             /** Format: uuid */
             track_id: string;
@@ -1239,11 +1327,83 @@ export interface components {
             password: string;
             username: string;
         };
+        /** @description A peer's album folder surfaced for manual (interactive) album search. */
+        ManualAlbumCandidate: {
+            files: components["schemas"]["ManualAlbumFile"][];
+            folder: string;
+            has_free_upload_slot: boolean;
+            /**
+             * Format: int32
+             * @description How many of the album's tracks the automatic matcher can pair with a
+             *     file in this folder.
+             */
+            matched_tracks: number;
+            /** Format: int32 */
+            queue_length: number;
+            /** Format: int32 */
+            score: number;
+            /** Format: int64 */
+            total_size: number;
+            username: string;
+        };
+        /** @description One file inside a peer's album folder. */
+        ManualAlbumFile: {
+            /** Format: int32 */
+            bit_rate?: number | null;
+            extension?: string | null;
+            filename: string;
+            /** Format: int32 */
+            length_secs?: number | null;
+            /** Format: int64 */
+            size: number;
+        };
+        /**
+         * @description A user-chosen album folder to download, bypassing automatic selection.
+         *     Carries the file listing the user saw so the job doesn't have to search
+         *     again.
+         */
+        ManualAlbumSelection: {
+            files: components["schemas"]["ManualAlbumFile"][];
+            folder: string;
+            username: string;
+        };
+        /** @description A user-chosen file to download, bypassing automatic candidate selection. */
+        ManualDownloadSelection: {
+            filename: string;
+            /** Format: int64 */
+            size: number;
+            username: string;
+        };
         /**
          * @description How files are integrated into the music library during an external import.
          * @enum {string}
          */
         ManualImportMode: "copy" | "hardlink";
+        /**
+         * @description A single file offered by a peer, surfaced for manual (interactive) search
+         *     so the user can override automatic candidate selection.
+         */
+        ManualSearchCandidate: {
+            /** Format: int32 */
+            bit_rate?: number | null;
+            extension?: string | null;
+            filename: string;
+            has_free_upload_slot: boolean;
+            /** Format: int32 */
+            length_secs?: number | null;
+            /** @description Whether the automatic matcher would consider this file at all. */
+            plausible: boolean;
+            /** Format: int32 */
+            queue_length: number;
+            /**
+             * Format: int32
+             * @description The automatic matcher's score for this file.
+             */
+            score: number;
+            /** Format: int64 */
+            size: number;
+            username: string;
+        };
         /** @enum {string} */
         MatchKind: "fuzzy" | "isrc_exact";
         /** @enum {string} */
@@ -1508,8 +1668,10 @@ export interface operations {
         parameters: {
             query: {
                 query: string;
-                /** @description Comma-separated provider ids to search (e.g. `tidal,deezer`).
- *     Omitted or empty searches all enabled providers. */
+                /**
+                 * @description Comma-separated provider ids to search (e.g. `tidal,deezer`).
+                 *     Omitted or empty searches all enabled providers.
+                 */
                 providers?: string | null;
             };
             header?: never;
@@ -1722,6 +1884,82 @@ export interface operations {
             };
             /** @description Failed to remove album files */
             500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    manual_download_album: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Album UUID */
+                album_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ManualAlbumSelection"];
+            };
+        };
+        responses: {
+            /** @description Manual album download job enqueued */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Album not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Failed to enqueue download */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    manual_search_album: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Album UUID */
+                album_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Candidate album folders, best-matched first */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ManualAlbumCandidate"][];
+                };
+            };
+            /** @description Album not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description No search-capable download provider available */
+            503: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -2069,8 +2307,10 @@ export interface operations {
         parameters: {
             query: {
                 query: string;
-                /** @description Comma-separated provider ids to search (e.g. `tidal,deezer`).
- *     Omitted or empty searches all enabled providers. */
+                /**
+                 * @description Comma-separated provider ids to search (e.g. `tidal,deezer`).
+                 *     Omitted or empty searches all enabled providers.
+                 */
                 providers?: string | null;
             };
             header?: never;
@@ -2992,8 +3232,10 @@ export interface operations {
         parameters: {
             query: {
                 query: string;
-                /** @description Comma-separated provider ids to search (e.g. `tidal,deezer`).
- *     Omitted or empty searches all enabled providers. */
+                /**
+                 * @description Comma-separated provider ids to search (e.g. `tidal,deezer`).
+                 *     Omitted or empty searches all enabled providers.
+                 */
                 providers?: string | null;
             };
             header?: never;
@@ -3087,8 +3329,10 @@ export interface operations {
         parameters: {
             query: {
                 query: string;
-                /** @description Comma-separated provider ids to search (e.g. `tidal,deezer`).
- *     Omitted or empty searches all enabled providers. */
+                /**
+                 * @description Comma-separated provider ids to search (e.g. `tidal,deezer`).
+                 *     Omitted or empty searches all enabled providers.
+                 */
                 providers?: string | null;
             };
             header?: never;
@@ -3107,6 +3351,82 @@ export interface operations {
                 };
             };
             /** @description Provider search unavailable */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    manual_download_track: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Library track id */
+                track_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ManualDownloadSelection"];
+            };
+        };
+        responses: {
+            /** @description Manual download job enqueued */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Track not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Failed to enqueue download */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    manual_search_track: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Library track id */
+                track_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description All candidate files found for the track, best-scored first */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ManualSearchCandidate"][];
+                };
+            };
+            /** @description Track not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description No search-capable download provider available */
             503: {
                 headers: {
                     [name: string]: unknown;

--- a/frontend/src/lib/api/types.gen.ts
+++ b/frontend/src/lib/api/types.gen.ts
@@ -1334,10 +1334,16 @@ export interface components {
             has_free_upload_slot: boolean;
             /**
              * Format: int32
-             * @description How many of the album's tracks the automatic matcher can pair with a
-             *     file in this folder.
+             * @description How many of the album's tracks strictly title-match a file in this
+             *     folder.
              */
             matched_tracks: number;
+            /**
+             * Format: int32
+             * @description How many of the album's tracks a manual download would actually fetch
+             *     from this folder (strict matches plus track-number fallback).
+             */
+            pairable_tracks: number;
             /** Format: int32 */
             queue_length: number;
             /** Format: int32 */

--- a/frontend/src/routes/_app/artists/$artistId/albums/$albumId.tsx
+++ b/frontend/src/routes/_app/artists/$artistId/albums/$albumId.tsx
@@ -5,7 +5,9 @@ import {
   CheckIcon,
   DownloadIcon,
   ExternalLinkIcon,
+  Loader2Icon,
   RefreshCwIcon,
+  SearchIcon,
   Trash2Icon,
 } from "lucide-react";
 
@@ -22,6 +24,8 @@ import {
 import {
   useAcceptMatchSuggestion,
   useDismissMatchSuggestion,
+  useManualAlbumDownload,
+  useManualDownload,
   useRemoveAlbumFiles,
   useRetryDownload,
   useSetAlbumQuality,
@@ -44,6 +48,13 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 
 type Album = components["schemas"]["Album"];
 type TrackInfo = components["schemas"]["TrackInfo"];
@@ -53,6 +64,8 @@ type JobResponse = components["schemas"]["JobResponse"];
 type Quality = components["schemas"]["Quality"];
 type ArtistWithPriority = components["schemas"]["ArtistWithPriority"];
 type AlbumType = components["schemas"]["AlbumType"];
+type ManualSearchCandidate = components["schemas"]["ManualSearchCandidate"];
+type ManualAlbumCandidate = components["schemas"]["ManualAlbumCandidate"];
 
 export const Route = createFileRoute("/_app/artists/$artistId/albums/$albumId")({
   component: AlbumDetailPage,
@@ -226,6 +239,7 @@ function AlbumDetailContent({
   artistIdParam: string;
 }) {
   const [showRemoveFiles, setShowRemoveFiles] = useState(false);
+  const [showManualSearch, setShowManualSearch] = useState(false);
 
   const toggleAlbumMonitor = useToggleAlbumMonitor();
   const removeAlbumFiles = useRemoveAlbumFiles();
@@ -303,6 +317,10 @@ function AlbumDetailContent({
                 {retryDownload.isPending ? "Starting..." : "Download"}
               </Button>
             )}
+            <Button variant="outline" size="sm" onClick={() => setShowManualSearch(true)}>
+              <SearchIcon className="mr-1.5 size-3.5" />
+              Interactive Search
+            </Button>
             <MonitorButton
               monitored={album.monitored}
               onToggleMonitor={() =>
@@ -469,6 +487,16 @@ function AlbumDetailContent({
         )}
       </div>
 
+      {/* ── Album interactive search dialog ────────────────── */}
+      {showManualSearch && (
+        <ManualAlbumSearchDialog
+          album={album}
+          trackCount={trackCount}
+          open={showManualSearch}
+          onOpenChange={setShowManualSearch}
+        />
+      )}
+
       {/* ── Remove files dialog ────────────────────────────── */}
       <AlertDialog open={showRemoveFiles} onOpenChange={setShowRemoveFiles}>
         <AlertDialogContent>
@@ -613,9 +641,10 @@ function TrackRow({
 }) {
   const toggleTrackMonitor = useToggleSingleTrackMonitor();
   const setTrackQuality = useSetTrackQuality();
+  const [showManualSearch, setShowManualSearch] = useState(false);
 
   return (
-    <div className="flex items-center gap-3 px-5 py-2.5 transition-colors duration-100 hover:bg-blue-500/3 dark:hover:bg-blue-500/5">
+    <div className="group flex items-center gap-3 px-5 py-2.5 transition-colors duration-100 hover:bg-blue-500/3 dark:hover:bg-blue-500/5">
       {/* Track status indicator */}
       <TrackStatusIndicator
         trackId={track.id}
@@ -669,9 +698,329 @@ function TrackRow({
         )}
       </div>
 
+      <Button
+        variant="ghost"
+        size="sm"
+        className="size-6 shrink-0 p-0 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100 max-md:opacity-100"
+        title="Interactive search"
+        onClick={() => setShowManualSearch(true)}
+      >
+        <SearchIcon className="size-3.5" />
+      </Button>
+
       <span className="shrink-0 text-xs text-muted-foreground tabular-nums">
         {formatDurationSeconds(track.duration_secs)}
       </span>
+
+      {showManualSearch && (
+        <ManualSearchDialog
+          track={track}
+          open={showManualSearch}
+          onOpenChange={setShowManualSearch}
+        />
+      )}
+    </div>
+  );
+}
+
+// ── Album manual (interactive) search dialog ───────────────────
+
+function candidateFolderName(folder: string): string {
+  const parts = folder.split(/[\\/]/).filter(Boolean);
+  return parts[parts.length - 1] ?? folder;
+}
+
+function ManualAlbumSearchDialog({
+  album,
+  trackCount,
+  open,
+  onOpenChange,
+}: {
+  album: Album;
+  trackCount: number;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const manualAlbumDownload = useManualAlbumDownload();
+
+  const { data, isLoading, isError } = $api.useQuery(
+    "get",
+    "/api/album/{album_id}/manual-search",
+    { params: { path: { album_id: album.id } } },
+    { enabled: open, staleTime: 5 * 60 * 1000, retry: false },
+  );
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="flex max-h-[85vh] flex-col sm:max-w-5xl">
+        <DialogHeader>
+          <DialogTitle>Interactive Search</DialogTitle>
+          <DialogDescription>
+            Album folders peers offered for &ldquo;{album.title}&rdquo;. Pick one to download all
+            its tracks from that folder.
+          </DialogDescription>
+        </DialogHeader>
+
+        {isLoading && (
+          <div className="flex items-center justify-center gap-2 py-10 text-sm text-muted-foreground">
+            <Loader2Icon className="size-4 animate-spin" />
+            Searching peers&hellip; this can take up to a minute.
+          </div>
+        )}
+
+        {isError && (
+          <div className="rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700 dark:border-red-900/50 dark:bg-red-950/50 dark:text-red-400">
+            Search failed. Check that the download provider is reachable and try again.
+          </div>
+        )}
+
+        {data && data.length === 0 && (
+          <div className="py-10 text-center text-sm text-muted-foreground">
+            No album folders found.
+          </div>
+        )}
+
+        {data && data.length > 0 && (
+          <div className="min-h-0 flex-1 overflow-y-auto rounded-lg border">
+            <div className="divide-y divide-border/50">
+              {data.map((candidate) => (
+                <ManualAlbumCandidateRow
+                  key={`${candidate.username}:${candidate.folder}`}
+                  candidate={candidate}
+                  albumId={album.id}
+                  trackCount={trackCount}
+                  mutation={manualAlbumDownload}
+                  onDownloaded={() => onOpenChange(false)}
+                />
+              ))}
+            </div>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function ManualAlbumCandidateRow({
+  candidate,
+  albumId,
+  trackCount,
+  mutation,
+  onDownloaded,
+}: {
+  candidate: ManualAlbumCandidate;
+  albumId: string;
+  trackCount: number;
+  mutation: ReturnType<typeof useManualAlbumDownload>;
+  onDownloaded: () => void;
+}) {
+  const isThisPending = mutation.isPending && mutation.variables.body.folder === candidate.folder;
+  const fullMatch = candidate.matched_tracks >= trackCount;
+
+  return (
+    <div className="flex items-center gap-3 px-3 py-2 text-sm hover:bg-blue-500/3 dark:hover:bg-blue-500/5">
+      <div className="min-w-0 flex-1">
+        <div className="truncate" title={candidate.folder}>
+          {candidateFolderName(candidate.folder)}
+        </div>
+        <div className="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-[11px] text-muted-foreground">
+          <span className="font-medium">{candidate.username}</span>
+          <span>{candidate.files.length} files</span>
+          <span>{formatFileSize(candidate.total_size)}</span>
+          <span>score {candidate.score}</span>
+          {!candidate.has_free_upload_slot && candidate.queue_length > 0 && (
+            <span>queue {candidate.queue_length}</span>
+          )}
+        </div>
+      </div>
+
+      <Badge
+        className={
+          fullMatch
+            ? "shrink-0 bg-green-500/10 text-green-600"
+            : "shrink-0 bg-amber-500/10 text-amber-600"
+        }
+      >
+        {candidate.matched_tracks}/{trackCount} tracks
+      </Badge>
+
+      <Button
+        size="sm"
+        variant="outline"
+        className="shrink-0"
+        disabled={mutation.isPending}
+        onClick={() =>
+          mutation.mutate(
+            {
+              params: { path: { album_id: albumId } },
+              body: {
+                username: candidate.username,
+                folder: candidate.folder,
+                files: candidate.files,
+              },
+            },
+            { onSuccess: onDownloaded },
+          )
+        }
+      >
+        {isThisPending ? (
+          <Loader2Icon className="size-3.5 animate-spin" />
+        ) : (
+          <DownloadIcon className="size-3.5" />
+        )}
+      </Button>
+    </div>
+  );
+}
+
+// ── Manual (interactive) search dialog ─────────────────────────
+
+function formatFileSize(bytes: number): string {
+  const mb = bytes / (1024 * 1024);
+  return mb >= 100 ? `${String(Math.round(mb))} MB` : `${mb.toFixed(1)} MB`;
+}
+
+function candidateBasename(filename: string): string {
+  const parts = filename.split(/[\\/]/);
+  return parts[parts.length - 1] ?? filename;
+}
+
+function ManualSearchDialog({
+  track,
+  open,
+  onOpenChange,
+}: {
+  track: TrackInfo;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const manualDownload = useManualDownload();
+
+  const { data, isLoading, isError } = $api.useQuery(
+    "get",
+    "/api/track/{track_id}/manual-search",
+    { params: { path: { track_id: track.id } } },
+    { enabled: open, staleTime: 5 * 60 * 1000, retry: false },
+  );
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="flex max-h-[85vh] flex-col sm:max-w-5xl">
+        <DialogHeader>
+          <DialogTitle>Interactive Search</DialogTitle>
+          <DialogDescription>
+            Every file peers offered for &ldquo;{track.title}&rdquo;. Pick one to download, even if
+            the automatic matcher rejected it.
+          </DialogDescription>
+        </DialogHeader>
+
+        {isLoading && (
+          <div className="flex items-center justify-center gap-2 py-10 text-sm text-muted-foreground">
+            <Loader2Icon className="size-4 animate-spin" />
+            Searching peers&hellip; this can take up to a minute.
+          </div>
+        )}
+
+        {isError && (
+          <div className="rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700 dark:border-red-900/50 dark:bg-red-950/50 dark:text-red-400">
+            Search failed. Check that the download provider is reachable and try again.
+          </div>
+        )}
+
+        {data && data.length === 0 && (
+          <div className="py-10 text-center text-sm text-muted-foreground">
+            No files found for this track.
+          </div>
+        )}
+
+        {data && data.length > 0 && (
+          <div className="min-h-0 flex-1 overflow-y-auto rounded-lg border">
+            <div className="divide-y divide-border/50">
+              {data.map((candidate) => (
+                <ManualSearchCandidateRow
+                  key={`${candidate.username}:${candidate.filename}`}
+                  candidate={candidate}
+                  trackId={track.id}
+                  mutation={manualDownload}
+                  onDownloaded={() => onOpenChange(false)}
+                />
+              ))}
+            </div>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function ManualSearchCandidateRow({
+  candidate,
+  trackId,
+  mutation,
+  onDownloaded,
+}: {
+  candidate: ManualSearchCandidate;
+  trackId: string;
+  mutation: ReturnType<typeof useManualDownload>;
+  onDownloaded: () => void;
+}) {
+  const isThisPending =
+    mutation.isPending && mutation.variables.body.filename === candidate.filename;
+
+  return (
+    <div className="flex items-center gap-3 px-3 py-2 text-sm hover:bg-blue-500/3 dark:hover:bg-blue-500/5">
+      <div className="min-w-0 flex-1">
+        <div className="truncate" title={candidate.filename}>
+          {candidateBasename(candidate.filename)}
+        </div>
+        <div className="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-[11px] text-muted-foreground">
+          <span className="font-medium">{candidate.username}</span>
+          {candidate.extension && <span className="uppercase">{candidate.extension}</span>}
+          <span>{formatFileSize(candidate.size)}</span>
+          {candidate.length_secs != null && (
+            <span>{formatDurationSeconds(candidate.length_secs)}</span>
+          )}
+          {candidate.bit_rate != null && <span>{String(candidate.bit_rate)} kbps</span>}
+          <span>score {candidate.score}</span>
+          {!candidate.has_free_upload_slot && candidate.queue_length > 0 && (
+            <span>queue {candidate.queue_length}</span>
+          )}
+        </div>
+      </div>
+
+      {candidate.plausible ? (
+        <Badge className="shrink-0 bg-green-500/10 text-green-600">match</Badge>
+      ) : (
+        <Badge variant="outline" className="shrink-0 text-muted-foreground">
+          rejected
+        </Badge>
+      )}
+
+      <Button
+        size="sm"
+        variant="outline"
+        className="shrink-0"
+        disabled={mutation.isPending}
+        onClick={() =>
+          mutation.mutate(
+            {
+              params: { path: { track_id: trackId } },
+              body: {
+                username: candidate.username,
+                filename: candidate.filename,
+                size: candidate.size,
+              },
+            },
+            { onSuccess: onDownloaded },
+          )
+        }
+      >
+        {isThisPending ? (
+          <Loader2Icon className="size-3.5 animate-spin" />
+        ) : (
+          <DownloadIcon className="size-3.5" />
+        )}
+      </Button>
     </div>
   );
 }

--- a/frontend/src/routes/_app/artists/$artistId/albums/$albumId.tsx
+++ b/frontend/src/routes/_app/artists/$artistId/albums/$albumId.tsx
@@ -815,7 +815,7 @@ function ManualAlbumCandidateRow({
   onDownloaded: () => void;
 }) {
   const isThisPending = mutation.isPending && mutation.variables.body.folder === candidate.folder;
-  const fullMatch = candidate.matched_tracks >= trackCount;
+  const fullMatch = candidate.pairable_tracks >= trackCount;
 
   return (
     <div className="flex items-center gap-3 px-3 py-2 text-sm hover:bg-blue-500/3 dark:hover:bg-blue-500/5">
@@ -828,6 +828,7 @@ function ManualAlbumCandidateRow({
           <span>{candidate.files.length} files</span>
           <span>{formatFileSize(candidate.total_size)}</span>
           <span>score {candidate.score}</span>
+          <span>{candidate.matched_tracks} title-matched</span>
           {!candidate.has_free_upload_slot && candidate.queue_length > 0 && (
             <span>queue {candidate.queue_length}</span>
           )}
@@ -840,8 +841,9 @@ function ManualAlbumCandidateRow({
             ? "shrink-0 bg-green-500/10 text-green-600"
             : "shrink-0 bg-amber-500/10 text-amber-600"
         }
+        title="Tracks a download of this folder would fetch"
       >
-        {candidate.matched_tracks}/{trackCount} tracks
+        {candidate.pairable_tracks}/{trackCount} tracks
       </Badge>
 
       <Button


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Interactive Search flow for albums and tracks, letting users browse ranked peer folders/files and start manual downloads.
  * Added manual album/track download actions that submit selections and refresh jobs/status views.
* **Bug Fixes**
  * Improved provider matching and selection with stronger title/token scoring and “wrong version” filtering.
  * Downloads now verify the audio/duration before accepting results, and retry using ranked alternatives on failure.
* **Improvements**
  * Enhanced fuzzy-text normalisation (including accented and non‑Latin titles).
  * Manual album downloads are more resilient, continuing when individual tracks fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->